### PR TITLE
Fix: compliance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ to a section with the version name.
 ## Unreleased Changes
 
 * Fix errors from non-escaped content in simplified invoice XML: Customer name, item name, etc.
+* Fix and revamp simplified invoice compliance checks
+  * Move compliance checks to the background queue to avoid timeouts
+  * Add progress reporting
+  * Tax category is now required for the compliance check since we've added a validation for it on invoice validate
+  * Require all fields in the compliance prompt
+  * Report the detailed ZATCA responses in an error log and link to it after the operation to enable users to report 
+    problems
 
 ## 0.16.0
 

--- a/ksa_compliance/compliance_checks.py
+++ b/ksa_compliance/compliance_checks.py
@@ -1,6 +1,7 @@
-from typing import NoReturn, cast
+from typing import NoReturn, cast, Optional, Tuple
 
 import frappe
+import frappe.utils.background_jobs
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice, make_sales_return
 from result import is_ok
 
@@ -10,52 +11,105 @@ from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales
 from ksa_compliance.ksa_compliance.doctype.zatca_business_settings.zatca_business_settings import ZATCABusinessSettings
 from ksa_compliance.standard_doctypes.sales_invoice import ignore_additional_fields_for_invoice, \
     clear_additional_fields_ignore_list
+from ksa_compliance.translation import ft
 
 
 @frappe.whitelist()
-def perform_compliance_checks(business_settings_id: str, customer_id: str, item_id: str) -> NoReturn:
+def perform_compliance_checks(business_settings_id: str, customer_id: str, item_id: str,
+                              tax_category_id: str) -> NoReturn:
+    frappe.utils.background_jobs.enqueue(
+        _perform_compliance_checks, business_settings_id=business_settings_id, customer_id=customer_id, item_id=item_id,
+        tax_category_id=tax_category_id)
+
+
+def _perform_compliance_checks(business_settings_id: str, customer_id: str, item_id: str,
+                               tax_category_id: str) -> NoReturn:
+    def progress(description: str, percent: float) -> None:
+        logger.info(f"[Compliance Check] {description} ({percent}%)")
+        frappe.publish_progress(title=ft('Compliance Check'), description=description, percent=percent)
+
     try:
         settings = cast(ZATCABusinessSettings, frappe.get_doc('ZATCA Business Settings', business_settings_id))
 
-        logger.info("Checking simplified invoice compliance")
-        invoice = make_invoice(settings.company, customer_id, item_id)
+        progress(ft('Creating simplified invoice'), 0.0)
+        invoice = make_invoice(settings.company, customer_id, item_id, tax_category_id)
+        invoice.save()
+
+        progress(ft('Submitting simplified invoice'), 11.0)
         ignore_additional_fields_for_invoice(invoice.name)
         invoice.submit()
-        result = check_invoice_compliance(invoice)
 
-        logger.info("Checking credit note compliance")
+        progress(ft('Checking simplified invoice compliance'), 22.0)
+        result, details = check_invoice_compliance(invoice)
+
+        # We need to check the credit note and debit note separately, so we roll back to this save point after checking
+        # the credit note. Otherwise, the debit note ends up with 0 qty for the item (since the credit note returns it)
+        frappe.db.savepoint('before_credit_note')
+
+        progress(ft('Creating simplified credit note'), 33.0)
         return_invoice = cast(SalesInvoice, make_sales_return(invoice.name))
         return_invoice.custom_return_reason = 'Goods returned'
         return_invoice.set_taxes()
         return_invoice.set_missing_values()
         return_invoice.save()
-        credit_note_result = check_invoice_compliance(return_invoice)
 
-        logger.info("Checking debit note compliance")
+        progress(ft('Submitting simplified credit note'), 44.0)
+        ignore_additional_fields_for_invoice(return_invoice.name)
+        return_invoice.submit()
+
+        progress(ft('Checking simplified credit note compliance'), 55.0)
+        credit_note_result, credit_note_details = check_invoice_compliance(return_invoice)
+
+        frappe.db.rollback(save_point='before_credit_note')
+        progress(ft('Creating simplified debit note'), 66.0)
         debit_invoice = cast(SalesInvoice, make_sales_return(invoice.name))
         debit_invoice.custom_return_reason = 'Goods returned'
         debit_invoice.is_debit_note = True
         debit_invoice.set_taxes()
         debit_invoice.set_missing_values()
         debit_invoice.save()
-        debit_invoice.save()
-        debit_note_result = check_invoice_compliance(debit_invoice)
 
-        frappe.msgprint(f"""<ul>
-        <li>Simplified Invoice Result: {result}</li>
-        <li>Simplified Credit Note Result: {credit_note_result}</li>
-        <li>Simplified Debit Note Result: {debit_note_result}</li>
-        """)
+        progress(ft('Submitting simplified debit note'), 77.0)
+        ignore_additional_fields_for_invoice(debit_invoice.name)
+        debit_invoice.submit()
+
+        progress(ft('Checking simplified debit note compliance'), 88.0)
+        debit_note_result, debit_note_details = check_invoice_compliance(debit_invoice)
+
+        progress(ft('Done'), 100)
+
+        error_log = frappe.log_error(title='Compliance Check Result',
+                                     message=f"Simplified Invoice Result: {result}\n"
+                                             f"{details}\n"
+                                             f"Simplified Credit Note Result: {credit_note_result}\n"
+                                             f"{credit_note_details}\n"
+                                             f"Simplified Debit Note Result: {debit_note_result}\n"
+                                             f"{debit_note_details}\n")
+
+        # Submitting the above invoices results in a number of messages about payment reconciliation and the like,
+        # and we don't to show those with the result of the compliance check
+        frappe.clear_messages()
+
+        error_link = frappe.utils.get_link_to_form('Error Log', error_log.name)
+        frappe.msgprint(f"""
+    <ul>
+    <li>Simplified invoice result: {result}</li>
+    <li>Simplified credit note result: {credit_note_result}</li>
+    <li>Simplified debit note result: {debit_note_result}</li>
+    </ul>
+    <p>Please check Error Log {error_link} for ZATCA responses</p>
+    """, realtime=True)
     finally:
         clear_additional_fields_ignore_list()
         logger.info("Rolling back")
         frappe.db.rollback()
 
 
-def make_invoice(company: str, customer: str, item: str) -> SalesInvoice:
+def make_invoice(company: str, customer: str, item: str, tax_category_id: str) -> SalesInvoice:
     invoice = cast(SalesInvoice, frappe.new_doc('Sales Invoice'))
     invoice.company = company
     invoice.customer = customer
+    invoice.tax_category = tax_category_id
     invoice.set_taxes()
     invoice.append('items', {'item_code': item, 'qty': 1.0})
     invoice.set_missing_values()
@@ -63,11 +117,17 @@ def make_invoice(company: str, customer: str, item: str) -> SalesInvoice:
     return invoice
 
 
-def check_invoice_compliance(invoice: SalesInvoice) -> str:
+def check_invoice_compliance(invoice: SalesInvoice) -> Tuple[str, Optional[str]]:
     si_additional_fields_doc = cast(SalesInvoiceAdditionalFields, frappe.new_doc("Sales Invoice Additional Fields"))
     si_additional_fields_doc.send_mode = ZatcaSendMode.Compliance
     si_additional_fields_doc.sales_invoice = invoice.name
     si_additional_fields_doc.flags.ignore_permissions = True
     si_additional_fields_doc.insert()
     result = si_additional_fields_doc.submit_to_zatca()
-    return result.ok_value if is_ok(result) else result.err_value
+    if is_ok(result):
+        zatca_message = frappe.get_value('ZATCA Integration Log',
+                                         {'invoice_additional_fields_reference': si_additional_fields_doc.name},
+                                         ['zatca_message'])
+        return result.ok_value, zatca_message
+
+    return result.err_value, None

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.js
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.js
@@ -59,14 +59,23 @@ frappe.ui.form.on("ZATCA Business Settings", {
                 label: 'Customer',
                 fieldname: 'customer_id',
                 fieldtype: 'Link',
-                options: 'Customer'
+                options: 'Customer',
+                reqd: 1,
             },
             {
                 label: 'Item',
                 fieldname: 'item_id',
                 fieldtype: 'Link',
-                options: 'Item'
-            }
+                options: 'Item',
+                reqd: 1,
+            },
+            {
+                label: 'Tax Category',
+                fieldname: 'tax_category_id',
+                fieldtype: 'Link',
+                options: 'Tax Category',
+                reqd: 1,
+            },
         ], values => {
             frappe.call({
                 freeze: true,
@@ -76,6 +85,7 @@ frappe.ui.form.on("ZATCA Business Settings", {
                     business_settings_id: frm.doc.name,
                     customer_id: values.customer_id,
                     item_id: values.item_id,
+                    tax_category_id: values.tax_category_id,
                 },
             });
         });


### PR DESCRIPTION
* Move compliance checks to the background queue to avoid timeouts
* Add progress reporting
* Tax category is now required for the compliance check since we've added a validation for it on invoice validate
* Require all fields in the compliance prompt
* Report the detailed ZATCA responses in an error log and link to it after the operation to enable users to report problems