### PR TITLE
Prevent saving sales invoice for both phase 1 and phase 2 without tax rate in sales taxes and charges table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Add changes to the "Unreleased Changes" section. Once you create a version (and 
 to a section with the version name.
 
 ## Unreleased Changes
+* Validate that sales invoice has tax rate in Sales Taxes and Charges Table in Phase 1 and Phase 2.
+* Show all validation errors in one message on saving sales invoice.
 
 ## 0.20.1
 

--- a/ksa_compliance/standard_doctypes/sales_invoice.py
+++ b/ksa_compliance/standard_doctypes/sales_invoice.py
@@ -92,10 +92,16 @@ def prevent_cancellation_of_sales_invoice(self, method) -> None:
 
 
 def validate_sales_invoice(self, method) -> None:
+    valid = True
     if ZATCABusinessSettings.is_enabled_for_company(self.company):
         if not self.tax_category:
-            frappe.throw(msg=_("Please choose a Tax Category"), title=_("Tax Category Missing"))
+            frappe.msgprint(msg=_("Please choose a Tax Category"), title=_("Validation Error"), indicator="red")
+            valid = False
 
     if len(self.taxes) == 0:
-        frappe.throw(msg=_("Please include tax rate in Sales Taxes and Charges Table"),
-                     title=_("Tax Rate Is Not Specified"))
+        frappe.msgprint(msg=_("Please include tax rate in Sales Taxes and Charges Table"),
+                        title=_("Validation Error"), indicator="red")
+        valid = False
+
+    if not valid:
+        raise frappe.ValidationError()

--- a/ksa_compliance/standard_doctypes/sales_invoice.py
+++ b/ksa_compliance/standard_doctypes/sales_invoice.py
@@ -95,6 +95,7 @@ def validate_sales_invoice(self, method) -> None:
     if ZATCABusinessSettings.is_enabled_for_company(self.company):
         if not self.tax_category:
             frappe.throw(msg=_("Please choose a Tax Category"), title=_("Tax Category Missing"))
-        if len(self.taxes) == 0:
-            frappe.throw(msg=_("Please include tax rate in Sales Taxes and Charges Table"),
-                         title=_("Tax Rate Is Not Specified"))
+
+    if len(self.taxes) == 0:
+        frappe.throw(msg=_("Please include tax rate in Sales Taxes and Charges Table"),
+                     title=_("Tax Rate Is Not Specified"))


### PR DESCRIPTION
Due to that print formats are using item wise tax details we should not allow to submit a sales invoice with a tax rate in sales invoice for both phase 1 and phase 2