### PR TITLE
Fix buyer addtional ids not showing on creating customer

### DIFF
--- a/ksa_compliance/public/js/customer.js
+++ b/ksa_compliance/public/js/customer.js
@@ -10,7 +10,7 @@ frappe.ui.form.on("Customer", {
 
 function add_other_ids_if_new(frm) {
   // TODO: update permissions for child doctype
-  if (frm.is_new()) {
+  if (frm.doc.name && !frm.is_dirty() && frm.doc.custom_additional_ids.length === 0) {
     var buyer_id_list = [];
     buyer_id_list.push(
       {


### PR DESCRIPTION
Since customer could be created using quick entry the condition of frm.is_new() validates to false due to this behavior.