### PR TITLE
Fix prepayment issues

### DIFF
--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -18,7 +18,7 @@ from ksa_compliance.standard_doctypes.tax_category import map_tax_category
 from ksa_compliance.throw import fthrow
 from ksa_compliance.translation import ft
 
-from .prepayment_invoice.service import validate_prepayment_invoice_is_sent, update_result
+from .prepayment_invoice.service import update_result
 from .prepayment_invoice.prepayment_invoice_factory import prepayment_invoice_factory_create
 
 
@@ -975,7 +975,7 @@ class Einvoice:
             field_name='total_advance', source_doc=self.sales_invoice_doc, xml_name='prepaid_amount', parent='invoice'
         )
 
-        if self.sales_invoice_doc.is_rounded_total_disabled():
+        if self.sales_invoice_doc.doctype == 'Payment Entry' or self.sales_invoice_doc.is_rounded_total_disabled():
             self.result['invoice']['payable_amount'] = abs(
                 self.sales_invoice_doc.get(self.get_right_fieldname('grand_total', self.sales_invoice_doc.doctype))
             )
@@ -1059,7 +1059,6 @@ class Einvoice:
             return
         if self.sales_invoice_doc.doctype == 'Sales Invoice' and not self.sales_invoice_doc.advances:
             return
-        validate_prepayment_invoice_is_sent(self.sales_invoice_doc)
         self.result['prepayment_invoice'] = prepayment_invoice_factory_create(self.result, self.sales_invoice_doc)
         update_result(self.result, self.sales_invoice_doc)
         # --------------------------- END Getting Invoice's item lines ------------------------------

--- a/ksa_compliance/output_models/prepayment_invoice/invoice_line_factory.py
+++ b/ksa_compliance/output_models/prepayment_invoice/invoice_line_factory.py
@@ -14,7 +14,11 @@ from typing import cast
 
 def invoice_line_create(doc: SalesInvoice) -> list[dict]:
     """Create invoice lines from document advances"""
-    return [asdict(_create_invoice_line(advance, doc)) for advance in doc.advances]
+    return [
+        asdict(_create_invoice_line(advance, doc))
+        for advance in doc.advances
+        if frappe.db.get_value('Payment Entry', advance.reference_name, 'custom_prepayment_invoice')
+    ]
 
 
 def _create_invoice_line(advance: SalesInvoicePayment, doc: SalesInvoice) -> InvoiceLine:

--- a/ksa_compliance/output_models/prepayment_invoice/service.py
+++ b/ksa_compliance/output_models/prepayment_invoice/service.py
@@ -1,6 +1,3 @@
-from frappe import _
-import frappe
-
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice
 
 
@@ -14,29 +11,3 @@ def update_result(result: dict, doc: SalesInvoice) -> None:
     result['invoice']['payable_amount'] = (
         result['invoice']['payable_amount'] - result['prepayment_invoice']['prepaid_amount']
     )
-
-
-def validate_prepayment_invoice_is_sent(doc: SalesInvoice) -> None:
-    SalesInvoiceAdvance = frappe.qb.DocType('Sales Invoice Advance')
-    PaymentEntry = frappe.qb.DocType('Payment Entry')
-    advances = (
-        frappe.qb.from_(SalesInvoiceAdvance)
-        .select(
-            SalesInvoiceAdvance.reference_type,
-            SalesInvoiceAdvance.reference_name,
-            PaymentEntry.custom_prepayment_invoice,
-        )
-        .where((SalesInvoiceAdvance.parent == doc.name))
-        .where(SalesInvoiceAdvance.reference_type == 'Payment Entry')
-        .inner_join(PaymentEntry)
-        .on(SalesInvoiceAdvance.reference_name == PaymentEntry.name)
-        .where(PaymentEntry.docstatus == 1)
-        .where(PaymentEntry.custom_prepayment_invoice == 0)
-    ).run(as_dict=True)
-    if advances:
-        frappe.throw(
-            _('Prepayment Invoice is not sent for {0}').format(
-                ', '.join([advance['reference_name'] for advance in advances])
-            ),
-            title=_('Prepayment Invoice Not Sent'),
-        )

--- a/ksa_compliance/translations/ar.csv
+++ b/ksa_compliance/translations/ar.csv
@@ -364,3 +364,4 @@ Issue date is mandatory, تاريخ الإصدار إلزامي
 Issue time is mandatory, وقت الإصدار إلزامي
 Document type code is mandatory, كود نوع المستند إلزامي
 Prepayment Invoice Not Sent,فاتورة الدفع المسبق لم يتم إرسالها
+By checking this box, you acknowledge that this Payment Entry will be treated as a Prepayment Invoice and submitted to ZATCA.,باختيار هذا المربع، فإنك تقر بأن إدخال الدفع هذا سيتم معاملته كفاتورة مسبقة وسيتم تقديمه إلى الهيئة العامة للزكاة والدخل (ZATCA).


### PR DESCRIPTION
Solved Error Message for rounded total field
removed advance payment check in sales invoice advance table as the business need now sales invoice could has multiple advance payment some has prepayment check and other are not checked by default unchecked prepayment advance payment does not sent to zatca aded condition to only send to zatca advance payment checked prepayment advance
add line in translation