### PR TITLE
fix: use custom_grand_total_without_rounding for BT-112 (TaxInclusive…

### DIFF
--- a/ksa_compliance/templates/e_invoice.xml
+++ b/ksa_compliance/templates/e_invoice.xml
@@ -197,7 +197,8 @@
     <cac:LegalMonetaryTotal>
         <cbc:LineExtensionAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.line_extension_amount, 2) }}</cbc:LineExtensionAmount>
         <cbc:TaxExclusiveAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.net_total, 2) }}</cbc:TaxExclusiveAmount>
-        <cbc:TaxInclusiveAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.grand_total, 2) }}</cbc:TaxInclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.custom_grand_total_without_rounding, 2) }}</cbc:TaxInclusiveAmount>
+
         <cbc:AllowanceTotalAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.allowance_total_amount, 2) }}</cbc:AllowanceTotalAmount>
         {% if invoice.rounding_adjustment %}
         <cbc:PayableRoundingAmount currencyID="{{ invoice.currency_code }}">{{ rounded(invoice.rounding_adjustment, 2) }}</cbc:PayableRoundingAmount>


### PR DESCRIPTION
…Amount) in UBL XML

fix: use custom_grand_total_without_rounding for BT-112 (TaxInclusiveAmount) in UBL XML

- Replaced invoice.grand_total with custom_grand_total_without_rounding in the XML template
- Prevents BR-CO-15 validation error by ensuring BT-112 = BT-109 + BT-110 exactly
- This ensures compatibility with mixed tax rates (15%, 0%) and avoids ERPNext's internal rounding
- Does not affect ERP logic or printed values — this is strictly for ZATCA complianc