### PR TITLE
Feat/rowwise tax rounding clean

### DIFF
--- a/ksa_compliance/hooks.py
+++ b/ksa_compliance/hooks.py
@@ -125,9 +125,11 @@ after_install = 'ksa_compliance.setup.after_install'
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-# "ToDo": "custom_app.overrides.CustomToDo"
-# }
+override_doctype_class = {
+    "Sales Invoice": "ksa_compliance.overrides.rowwise_rounding.SalesInvoiceKSA",
+    "POS Invoice": "ksa_compliance.overrides.rowwise_rounding.POSInvoiceKSA",
+    "Sales Order": "ksa_compliance.overrides.rowwise_rounding.SalesOrderKSA"
+}
 
 # Document Events
 # ---------------

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
@@ -1,12 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{company}-{country}-{currency}",
+ "autoname": "format:{company}-{country}-{currency}-{##}",
  "creation": "2024-01-11 15:31:56.241248",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "tab_break_ljdo",
+  "status",
   "company",
   "company_unit",
   "company_unit_serial",
@@ -35,6 +36,7 @@
   "section_break_muug",
   "other_ids",
   "vat_account_configuration_tab",
+  "column_break_izkt",
   "automatic_vat_account_configuration",
   "linked_tax_account",
   "account_name",
@@ -228,6 +230,7 @@
    "fieldname": "compliance_request_id",
    "fieldtype": "Data",
    "label": "Compliance Request ID",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -245,6 +248,7 @@
    "fieldname": "company_unit_serial",
    "fieldtype": "Data",
    "label": "Company Unit Serial",
+   "no_copy": 1,
    "read_only_depends_on": "eval:frappe.user_roles.indexOf('System Manager') === -1 && doc.production_request_id",
    "reqd": 1
   },
@@ -260,18 +264,21 @@
    "fieldname": "csr",
    "fieldtype": "Small Text",
    "label": "CSR",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "security_token",
    "fieldtype": "Small Text",
    "label": "Security Token",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "secret",
    "fieldtype": "Password",
    "label": "Secret",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -288,12 +295,14 @@
    "fieldname": "production_security_token",
    "fieldtype": "Small Text",
    "label": "Production Security Token",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "production_secret",
    "fieldtype": "Password",
    "label": "Production Secret",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -310,6 +319,7 @@
    "fieldname": "production_request_id",
    "fieldtype": "Data",
    "label": "Production Request ID",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -334,6 +344,7 @@
    "fieldname": "zatca_cli_path",
    "fieldtype": "Data",
    "label": "CLI Path",
+   "no_copy": 1,
    "read_only_depends_on": "eval:doc.cli_setup==='Automatic'"
   },
   {
@@ -348,6 +359,7 @@
    "fieldname": "cli_setup",
    "fieldtype": "Select",
    "label": "CLI Setup",
+   "no_copy": 1,
    "options": "Automatic\nManual",
    "reqd": 1
   },
@@ -376,6 +388,7 @@
    "fieldname": "java_home",
    "fieldtype": "Data",
    "label": "Java Home",
+   "no_copy": 1,
    "read_only_depends_on": "eval:doc.cli_setup === 'Automatic'"
   },
   {
@@ -417,6 +430,7 @@
    "fieldtype": "Percent",
    "label": "Tax Rate",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
+   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -426,6 +440,7 @@
    "fieldtype": "Select",
    "label": "ZATCA Tax Category",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
+   "no_copy": 1,
    "options": "\nStandard rate\nServices outside scope of tax / Not subject to VAT || {manual entry}\nExempt from Tax || Financial services mentioned in Article 29 of the VAT Regulations\nExempt from Tax || Life insurance services mentioned in Article 29 of the VAT Regulations\nExempt from Tax || Real estate transactions mentioned in Article 30 of the VAT Regulations\nExempt from Tax || Qualified Supply of Goods in Duty Free area\nZero rated goods || Export of goods\nZero rated goods || Export of services\nZero rated goods || The international transport of Goods\nZero rated goods || International transport of passengers\nZero rated goods || Services directly connected and incidental to a Supply of international passenger transport\nZero rated goods || Supply of a qualifying means of transport\nZero rated goods || Any services relating to Goods or passenger transportation as defined in article twenty five of these Regulations\nZero rated goods || Medicines and medical equipment\nZero rated goods || Qualifying metals\nZero rated goods || Private education to citizen\nZero rated goods || Private healthcare to citizen\nZero rated goods || Supply of qualified military goods",
    "set_only_once": 1
   },
@@ -434,6 +449,7 @@
    "fieldname": "linked_tax_account",
    "fieldtype": "Link",
    "label": "Linked Tax Account",
+   "no_copy": 1,
    "options": "Account",
    "read_only": 1
   },
@@ -444,6 +460,7 @@
    "fieldtype": "Data",
    "label": "Account Name",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
+   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -453,6 +470,7 @@
    "fieldtype": "Data",
    "label": "Account Number",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
+   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -469,6 +487,7 @@
    "fieldname": "automatic_vat_account_configuration",
    "fieldtype": "Check",
    "label": "Automatic VAT Account Configuration",
+   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -487,6 +506,20 @@
    "fieldtype": "Section Break"
   },
   {
+   "default": "Active",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Active\nRevoked"
+  },
+  {
+   "fieldname": "column_break_izkt",
+   "fieldtype": "Column Break",
+   "no_copy": 1
+  },
+  {
    "default": "0",
    "fieldname": "enable_row_wise_rounding",
    "fieldtype": "Check",
@@ -495,7 +528,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-03 16:22:07.825186",
+ "modified": "2025-09-03 16:47:32.909210",
  "modified_by": "Administrator",
  "module": "KSA Compliance",
  "name": "ZATCA Business Settings",
@@ -518,7 +551,16 @@
  "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
+ "states": [
+  {
+   "color": "Blue",
+   "title": "Active"
+  },
+  {
+   "color": "Red",
+   "title": "Revoked"
+  }
+ ],
  "title_field": "company",
  "track_changes": 1
 }

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
@@ -1,13 +1,12 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{company}-{country}-{currency}-{##}",
+ "autoname": "format:{company}-{country}-{currency}",
  "creation": "2024-01-11 15:31:56.241248",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "tab_break_ljdo",
-  "status",
   "company",
   "company_unit",
   "company_unit_serial",
@@ -15,6 +14,7 @@
   "country",
   "country_code",
   "enable_zatca_integration",
+  "enable_row_wise_rounding",
   "sync_with_zatca",
   "type_of_business_transactions",
   "currency",
@@ -35,7 +35,6 @@
   "section_break_muug",
   "other_ids",
   "vat_account_configuration_tab",
-  "column_break_izkt",
   "automatic_vat_account_configuration",
   "linked_tax_account",
   "account_name",
@@ -229,7 +228,6 @@
    "fieldname": "compliance_request_id",
    "fieldtype": "Data",
    "label": "Compliance Request ID",
-   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -247,7 +245,6 @@
    "fieldname": "company_unit_serial",
    "fieldtype": "Data",
    "label": "Company Unit Serial",
-   "no_copy": 1,
    "read_only_depends_on": "eval:frappe.user_roles.indexOf('System Manager') === -1 && doc.production_request_id",
    "reqd": 1
   },
@@ -263,21 +260,18 @@
    "fieldname": "csr",
    "fieldtype": "Small Text",
    "label": "CSR",
-   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "security_token",
    "fieldtype": "Small Text",
    "label": "Security Token",
-   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "secret",
    "fieldtype": "Password",
    "label": "Secret",
-   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -294,14 +288,12 @@
    "fieldname": "production_security_token",
    "fieldtype": "Small Text",
    "label": "Production Security Token",
-   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "production_secret",
    "fieldtype": "Password",
    "label": "Production Secret",
-   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -318,7 +310,6 @@
    "fieldname": "production_request_id",
    "fieldtype": "Data",
    "label": "Production Request ID",
-   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -343,7 +334,6 @@
    "fieldname": "zatca_cli_path",
    "fieldtype": "Data",
    "label": "CLI Path",
-   "no_copy": 1,
    "read_only_depends_on": "eval:doc.cli_setup==='Automatic'"
   },
   {
@@ -358,7 +348,6 @@
    "fieldname": "cli_setup",
    "fieldtype": "Select",
    "label": "CLI Setup",
-   "no_copy": 1,
    "options": "Automatic\nManual",
    "reqd": 1
   },
@@ -387,7 +376,6 @@
    "fieldname": "java_home",
    "fieldtype": "Data",
    "label": "Java Home",
-   "no_copy": 1,
    "read_only_depends_on": "eval:doc.cli_setup === 'Automatic'"
   },
   {
@@ -429,7 +417,6 @@
    "fieldtype": "Percent",
    "label": "Tax Rate",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
-   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -439,7 +426,6 @@
    "fieldtype": "Select",
    "label": "ZATCA Tax Category",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
-   "no_copy": 1,
    "options": "\nStandard rate\nServices outside scope of tax / Not subject to VAT || {manual entry}\nExempt from Tax || Financial services mentioned in Article 29 of the VAT Regulations\nExempt from Tax || Life insurance services mentioned in Article 29 of the VAT Regulations\nExempt from Tax || Real estate transactions mentioned in Article 30 of the VAT Regulations\nExempt from Tax || Qualified Supply of Goods in Duty Free area\nZero rated goods || Export of goods\nZero rated goods || Export of services\nZero rated goods || The international transport of Goods\nZero rated goods || International transport of passengers\nZero rated goods || Services directly connected and incidental to a Supply of international passenger transport\nZero rated goods || Supply of a qualifying means of transport\nZero rated goods || Any services relating to Goods or passenger transportation as defined in article twenty five of these Regulations\nZero rated goods || Medicines and medical equipment\nZero rated goods || Qualifying metals\nZero rated goods || Private education to citizen\nZero rated goods || Private healthcare to citizen\nZero rated goods || Supply of qualified military goods",
    "set_only_once": 1
   },
@@ -448,7 +434,6 @@
    "fieldname": "linked_tax_account",
    "fieldtype": "Link",
    "label": "Linked Tax Account",
-   "no_copy": 1,
    "options": "Account",
    "read_only": 1
   },
@@ -459,7 +444,6 @@
    "fieldtype": "Data",
    "label": "Account Name",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
-   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -469,7 +453,6 @@
    "fieldtype": "Data",
    "label": "Account Number",
    "mandatory_depends_on": "eval:doc.automatic_vat_account_configuration === 1",
-   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -486,7 +469,6 @@
    "fieldname": "automatic_vat_account_configuration",
    "fieldtype": "Check",
    "label": "Automatic VAT Account Configuration",
-   "no_copy": 1,
    "set_only_once": 1
   },
   {
@@ -505,23 +487,15 @@
    "fieldtype": "Section Break"
   },
   {
-   "default": "Active",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "hidden": 1,
-   "label": "Status",
-   "no_copy": 1,
-   "options": "Active\nRevoked"
-  },
-  {
-   "fieldname": "column_break_izkt",
-   "fieldtype": "Column Break",
-   "no_copy": 1
+   "default": "0",
+   "fieldname": "enable_row_wise_rounding",
+   "fieldtype": "Check",
+   "label": "Enable Row wise Rounding"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-20 11:06:24.795298",
+ "modified": "2025-09-03 16:22:07.825186",
  "modified_by": "Administrator",
  "module": "KSA Compliance",
  "name": "ZATCA Business Settings",
@@ -541,18 +515,10 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [
-  {
-   "color": "Blue",
-   "title": "Active"
-  },
-  {
-   "color": "Red",
-   "title": "Revoked"
-  }
- ],
+ "states": [],
  "title_field": "company",
  "track_changes": 1
 }

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
@@ -76,6 +76,7 @@ class ZATCABusinessSettings(Document):
         secret: DF.Password | None
         security_token: DF.SmallText | None
         seller_name: DF.Data
+        status: DF.Literal["Active", "Revoked"]
         street: DF.Data | None
         sync_with_zatca: DF.Literal["Live", "Batches"]
         tax_rate: DF.Percent

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
@@ -39,9 +39,7 @@ class ZATCABusinessSettings(Document):
 
     if TYPE_CHECKING:
         from frappe.types import DF
-        from ksa_compliance.ksa_compliance.doctype.additional_seller_ids.additional_seller_ids import (
-            AdditionalSellerIDs,
-        )
+        from ksa_compliance.ksa_compliance.doctype.additional_seller_ids.additional_seller_ids import AdditionalSellerIDs
 
         account_name: DF.Data | None
         account_number: DF.Data | None
@@ -50,7 +48,7 @@ class ZATCABusinessSettings(Document):
         block_invoice_on_invalid_xml: DF.Check
         building_number: DF.Data | None
         city: DF.Data | None
-        cli_setup: DF.Literal['Automatic', 'Manual']
+        cli_setup: DF.Literal["Automatic", "Manual"]
         company: DF.Link
         company_address: DF.Link
         company_category: DF.Data
@@ -63,8 +61,9 @@ class ZATCABusinessSettings(Document):
         currency: DF.Link
         district: DF.Data | None
         enable_branch_configuration: DF.Check
+        enable_row_wise_rounding: DF.Check
         enable_zatca_integration: DF.Check
-        fatoora_server: DF.Literal['Sandbox', 'Simulation', 'Production']
+        fatoora_server: DF.Literal["Sandbox", "Simulation", "Production"]
         java_home: DF.Data | None
         linked_tax_account: DF.Link | None
         other_ids: DF.Table[AdditionalSellerIDs]
@@ -77,37 +76,14 @@ class ZATCABusinessSettings(Document):
         secret: DF.Password | None
         security_token: DF.SmallText | None
         seller_name: DF.Data
-        status: DF.Literal['Active', 'Revoked']
         street: DF.Data | None
-        sync_with_zatca: DF.Literal['Live', 'Batches']
+        sync_with_zatca: DF.Literal["Live", "Batches"]
         tax_rate: DF.Percent
-        type_of_business_transactions: DF.Literal[
-            'Let the system decide (both)', 'Simplified Tax Invoices', 'Standard Tax Invoices'
-        ]
+        type_of_business_transactions: DF.Literal["Let the system decide (both)", "Simplified Tax Invoices", "Standard Tax Invoices"]
         validate_generated_xml: DF.Check
         vat_registration_number: DF.Data
         zatca_cli_path: DF.Data | None
-        zatca_tax_category: DF.Literal[
-            '',
-            'Standard rate',
-            'Services outside scope of tax / Not subject to VAT || {manual entry}',
-            'Exempt from Tax || Financial services mentioned in Article 29 of the VAT Regulations',
-            'Exempt from Tax || Life insurance services mentioned in Article 29 of the VAT Regulations',
-            'Exempt from Tax || Real estate transactions mentioned in Article 30 of the VAT Regulations',
-            'Exempt from Tax || Qualified Supply of Goods in Duty Free area',
-            'Zero rated goods || Export of goods',
-            'Zero rated goods || Export of services',
-            'Zero rated goods || The international transport of Goods',
-            'Zero rated goods || International transport of passengers',
-            'Zero rated goods || Services directly connected and incidental to a Supply of international passenger transport',
-            'Zero rated goods || Supply of a qualifying means of transport',
-            'Zero rated goods || Any services relating to Goods or passenger transportation as defined in article twenty five of these Regulations',
-            'Zero rated goods || Medicines and medical equipment',
-            'Zero rated goods || Qualifying metals',
-            'Zero rated goods || Private education to citizen',
-            'Zero rated goods || Private healthcare to citizen',
-            'Zero rated goods || Supply of qualified military goods',
-        ]
+        zatca_tax_category: DF.Literal["", "Standard rate", "Services outside scope of tax / Not subject to VAT || {manual entry}", "Exempt from Tax || Financial services mentioned in Article 29 of the VAT Regulations", "Exempt from Tax || Life insurance services mentioned in Article 29 of the VAT Regulations", "Exempt from Tax || Real estate transactions mentioned in Article 30 of the VAT Regulations", "Exempt from Tax || Qualified Supply of Goods in Duty Free area", "Zero rated goods || Export of goods", "Zero rated goods || Export of services", "Zero rated goods || The international transport of Goods", "Zero rated goods || International transport of passengers", "Zero rated goods || Services directly connected and incidental to a Supply of international passenger transport", "Zero rated goods || Supply of a qualifying means of transport", "Zero rated goods || Any services relating to Goods or passenger transportation as defined in article twenty five of these Regulations", "Zero rated goods || Medicines and medical equipment", "Zero rated goods || Qualifying metals", "Zero rated goods || Private education to citizen", "Zero rated goods || Private healthcare to citizen", "Zero rated goods || Supply of qualified military goods"]
     # end: auto-generated types
 
     def after_insert(self):

--- a/ksa_compliance/overrides/rowwise_rounding.py
+++ b/ksa_compliance/overrides/rowwise_rounding.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+"""
+Row-wise VAT rounding for ERPNext sales docs driven by Company setting:
+ZATCA Business Settings.enable_row_wise_rounding
+Supported doctypes (via hooks override):
+- Sales Invoice
+- POS Invoice
+- Sales Order
+Design:
+- A single mixin (RowwiseVATMixin) implements the override safely.
+- Calls AccountsController.calculate_taxes_and_totals(self) explicitly (no super-recursion).
+- If company flag is ON -> rewrites item_wise_tax_detail with rounded per-line VAT,
+  updates tax rows & doc totals, then final trimming with proper precisions.
+"""
+
+from __future__ import annotations
+from typing import Dict, Iterable, List
+import json
+import functools
+
+import frappe
+from frappe.utils import flt
+from frappe.utils.data import rounded, cint
+
+# parent calc explicitly (avoid MRO loops)
+from erpnext.controllers.accounts_controller import AccountsController
+
+# original doctypes
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice as _SalesInvoice
+from erpnext.accounts.doctype.pos_invoice.pos_invoice import POSInvoice as _POSInvoice
+from erpnext.selling.doctype.sales_order.sales_order import SalesOrder as _SalesOrder
+
+
+# ------------- helpers -------------
+
+@functools.lru_cache(maxsize=256)
+def _company_rowwise_enabled(company: str) -> bool:
+    """Read company flag once from ZATCA Business Settings (cached)."""
+    if not company:
+        return False
+    enabled = frappe.get_value(
+        "ZATCA Business Settings",
+        {"company": company},
+        "enable_row_wise_rounding",
+    )
+    try:
+        return bool(int(enabled))
+    except Exception:
+        return bool(enabled)
+
+
+def _safe_doc_prec(doc, fieldname: str, fallback: int = 2) -> int:
+    try:
+        p = doc.precision(fieldname)
+        return int(p) if p is not None else fallback
+    except Exception:
+        return fallback
+
+
+def _round_set(obj, field: str, prec: int) -> None:
+    """Round obj.field to given precision if present & numeric-like."""
+    if not hasattr(obj, field):
+        return
+    val = getattr(obj, field)
+    if val is None:
+        return
+    try:
+        setattr(obj, field, rounded(flt(val), prec))
+    except Exception:
+        pass
+
+
+def _iter_items(doc) -> Iterable:
+    items = getattr(doc, "items", None)
+    return items or []
+
+
+def _parse_item_detail(raw: str) -> Dict:
+    if not raw:
+        return {}
+    try:
+        return frappe.parse_json(raw) or {}
+    except Exception:
+        try:
+            return json.loads(raw) or {}
+        except Exception:
+            return {}
+
+
+# ------------- mixin (shared logic) -------------
+
+class RowwiseVATMixin:
+    """Shared override: safe row-wise VAT rounding controlled by company flag."""
+    _RW_GUARD_ATTR = "_rw_rounding_in_progress"
+
+    def calculate_taxes_and_totals(self) -> None:  # type: ignore[override]
+        # guard against re-entry
+        if getattr(self, self._RW_GUARD_ATTR, False):
+            AccountsController.calculate_taxes_and_totals(self)
+            return
+
+        setattr(self, self._RW_GUARD_ATTR, True)
+        try:
+            # 1) Base calculation (ERPNext standard)
+            AccountsController.calculate_taxes_and_totals(self)
+
+            # 2) Company feature flag
+            if not _company_rowwise_enabled(getattr(self, "company", None)):
+                self._final_trim()
+                return
+
+            # 3) Row-wise VAT rounding (rewrite item_wise_tax_detail + update totals)
+            self._apply_rowwise_vat_rounding()
+
+            # 4) Final trimming
+            self._final_trim()
+
+        finally:
+            setattr(self, self._RW_GUARD_ATTR, False)
+
+    # ---------- internals ----------
+
+    def _apply_rowwise_vat_rounding(self) -> None:
+        """Rewrites tax.item_wise_tax_detail with rounded per-line VAT then updates totals."""
+        currency_prec = _safe_doc_prec(self, "grand_total", fallback=2)
+        base_prec = _safe_doc_prec(self, "base_grand_total", fallback=currency_prec)
+        conv_rate = flt(getattr(self, "conversion_rate", 1.0)) or 1.0
+
+        # Map item_code → list of child rows (same code may appear multiple times)
+        code_to_rows: Dict[str, List] = {}
+        for d in _iter_items(self):
+            code_to_rows.setdefault(d.item_code, []).append(d)
+
+        # accumulate per-row VAT across tax rows (optional if you want to store on row)
+        per_row_total_vat: Dict[str, float] = {d.name: 0.0 for d in _iter_items(self)}
+
+        total_taxes_after_round = 0.0
+
+        for tax in (getattr(self, "taxes", None) or []):
+            detail = _parse_item_detail(getattr(tax, "item_wise_tax_detail", None))
+            if not detail:
+                continue
+
+            rounded_sum_this_tax = 0.0
+            new_detail = {}
+
+            def _r(x: float) -> float:
+                return flt(x, currency_prec)
+
+            for item_code, payload in detail.items():
+                rows = code_to_rows.get(item_code, [])
+
+                # 1) [[rate, amount], ...]
+                if isinstance(payload, list) and payload and isinstance(payload[0], list):
+                    rounded_payload = []
+                    sum_for_code = 0.0
+                    for pair in payload:
+                        if isinstance(pair, list) and len(pair) == 2:
+                            r, amt = pair
+                            r_amt = _r(amt)
+                            rounded_payload.append([r, r_amt])
+                            sum_for_code += r_amt
+                        else:
+                            rounded_payload.append(pair)
+                    new_detail[item_code] = rounded_payload
+                    rounded_sum_this_tax += sum_for_code
+
+                    if rows and sum_for_code:
+                        total_net = sum([flt(r.get("net_amount") or r.get("amount") or 0.0) for r in rows]) or 1.0
+                        for r in rows:
+                            net = flt(r.get("net_amount") or r.get("amount") or 0.0)
+                            share = sum_for_code * (net / total_net)
+                            per_row_total_vat[r.name] = flt(per_row_total_vat.get(r.name, 0.0) + _r(share), currency_prec)
+
+                # 2) [rate, amount]
+                elif isinstance(payload, list) and len(payload) == 2 and all(isinstance(x, (int, float)) for x in payload):
+                    rate, amt = payload
+                    r_amt = _r(amt)
+                    new_detail[item_code] = [rate, r_amt]
+                    rounded_sum_this_tax += r_amt
+
+                    if rows and r_amt:
+                        total_net = sum([flt(r.get("net_amount") or r.get("amount") or 0.0) for r in rows]) or 1.0
+                        for r in rows:
+                            net = flt(r.get("net_amount") or r.get("amount") or 0.0)
+                            share = r_amt * (net / total_net)
+                            per_row_total_vat[r.name] = flt(per_row_total_vat.get(r.name, 0.0) + _r(share), currency_prec)
+
+                # 3) amount only
+                elif isinstance(payload, (int, float)):
+                    r_amt = _r(payload)
+                    new_detail[item_code] = r_amt
+                    rounded_sum_this_tax += r_amt
+
+                    if rows and r_amt:
+                        total_net = sum([flt(r.get("net_amount") or r.get("amount") or 0.0) for r in rows]) or 1.0
+                        for r in rows:
+                            net = flt(r.get("net_amount") or r.get("amount") or 0.0)
+                            share = r_amt * (net / total_net)
+                            per_row_total_vat[r.name] = flt(per_row_total_vat.get(r.name, 0.0) + _r(share), currency_prec)
+
+                else:
+                    # unexpected payload shape → keep as-is
+                    new_detail[item_code] = payload
+
+            # write back rounded detail
+            tax.item_wise_tax_detail = json.dumps(new_detail, ensure_ascii=False)
+
+            # update tax row totals
+            tax.tax_amount = flt(rounded_sum_this_tax, currency_prec)
+            tax.base_tax_amount = flt(rounded_sum_this_tax * conv_rate, base_prec)
+
+            if hasattr(tax, "total"):
+                tax.total = flt(getattr(tax, "total", 0.0), currency_prec)
+            if hasattr(tax, "base_total"):
+                tax.base_total = flt(getattr(tax, "base_total", 0.0), base_prec)
+
+            total_taxes_after_round += tax.tax_amount
+
+        # optional: write per-row VAT if fields exist
+        for d in _iter_items(self):
+            if hasattr(d, "item_tax_amount"):
+                d.item_tax_amount = flt(per_row_total_vat.get(d.name, 0.0), currency_prec)
+            if hasattr(d, "base_item_tax_amount"):
+                d.base_item_tax_amount = flt(per_row_total_vat.get(d.name, 0.0) * conv_rate, base_prec)
+
+        # update doc totals
+        self.total_taxes_and_charges = flt(total_taxes_after_round, currency_prec)
+        net_total = flt(getattr(self, "total", 0.0), currency_prec)
+        self.grand_total = flt(net_total + self.total_taxes_and_charges, currency_prec)
+        self.base_grand_total = flt(self.grand_total * conv_rate, base_prec)
+        self.rounded_total = self.grand_total
+        self.in_words = frappe.utils.money_in_words(self.grand_total, getattr(self, "currency", None))
+
+        # strong invariant
+        assert flt(net_total + self.total_taxes_and_charges, currency_prec) == self.grand_total, \
+            "Inconsistent totals after row-wise VAT rounding"
+
+    def _final_trim(self) -> None:
+        """Final rounding pass for doc/tax fields to eliminate float trails."""
+        currency_prec = _safe_doc_prec(self, "grand_total", fallback=2)
+        base_prec = _safe_doc_prec(self, "base_grand_total", fallback=currency_prec)
+
+        # doc-level currency fields
+        for f in [
+            "total", "net_total", "total_taxes_and_charges",
+            "grand_total", "rounded_total",
+            "paid_amount", "write_off_amount", "change_amount",
+            "discount_amount", "rounding_adjustment",
+            "outstanding_amount",
+        ]:
+            _round_set(self, f, currency_prec)
+
+        # doc-level base fields
+        for f in [
+            "base_total", "base_net_total", "base_total_taxes_and_charges",
+            "base_grand_total", "base_rounded_total",
+            "base_paid_amount", "base_write_off_amount",
+            "base_change_amount", "base_discount_amount",
+        ]:
+            _round_set(self, f, base_prec)
+
+        # per-tax rows
+        for tax in (getattr(self, "taxes", None) or []):
+            for f in (
+                "tax_amount", "total", "tax_amount_after_discount_amount",
+                "base_tax_amount", "base_total", "base_tax_amount_after_discount_amount",
+            ):
+                if f.startswith("base_"):
+                    _round_set(tax, f, base_prec)
+                else:
+                    _round_set(tax, f, currency_prec)
+
+
+# ------------- concrete overrides for hooks -------------
+
+class SalesInvoiceKSA(RowwiseVATMixin, _SalesInvoice):
+    """Override for Sales Invoice"""
+    pass
+
+
+class POSInvoiceKSA(RowwiseVATMixin, _POSInvoice):
+    """Override for POS Invoice"""
+    pass
+
+
+class SalesOrderKSA(RowwiseVATMixin, _SalesOrder):
+    """Override for Sales Order"""
+    pass
+
+
+__all__ = ["SalesInvoiceKSA", "POSInvoiceKSA", "SalesOrderKSA", "RowwiseVATMixin"]


### PR DESCRIPTION
المشكلة

عند توليد الفواتير في ERPNext باستخدام KSA Compliance، يحصل رفض من هيئة الزكاة والضريبة والجمارك (ZATCA) بسبب فروقات الهللات:

BR-CO-14: عدم تطابق إجمالي VAT (BT-110) مع مجموع ضرائب البنود (BT-117).

BR-CO-15 / BT-112: عدم تطابق إجمالي الفاتورة مع مجموع صافي الفاتورة + VAT.

السبب أن ERPNext يقوم بالتقريب على مستوى الإجمالي، بينما متطلبات ZATCA تشترط التقريب على مستوى كل بند (Row-wise).

الحل

إضافة override جديد لدالة calculate_taxes_and_totals بحيث:

يتم تقريب VAT على مستوى كل بند أولاً.

يتم إعادة تجميع الضرائب والإجماليات بعد التقريب.

يتم تحديث الحقول الرئيسية (total_taxes_and_charges, grand_total, base_grand_total …إلخ) لتطابق تمامًا متطلبات ZATCA.

تم تطبيق المنطق على:

Sales Invoice

POS Invoice

Sales Order

التفعيل يعتمد على إعداد الشركة في ZATCA Business Settings (enable_row_wise_rounding).

التأثير

معالجة فروقات الهللات نهائيًا في الفواتير المرسلة إلى ZATCA.

مطابقة قواعد التحقق الخاصة بـ BT-110 و BT-112.

لا يؤثر إلا إذا كان الحقل enable_row_wise_rounding مفعّلًا للشركة.

التحقق

تم اختبار عينات متعددة بفواتير تحوي:

أكثر من بند.

خصومات.

ضرائب متعددة.

النتائج:

Σ item VAT = BT-110 ✅

Net Total + VAT = Grand Total (BT-112) ✅

تم تمرير الفواتير في بيئة الاختبار (Sandbox) بنجاح بدون رفض.

✅ Checklist

إضافة ملف rowwise_rounding.py داخل overrides/.

تعديل hooks.py لإضافة override_doctype_class للـ Sales Invoice / POS Invoice / Sales Order.

استخدام إعداد الشركة (enable_row_wise_rounding) للتحكم في التفعيل.

اختبار محلي على بيئة Development.

تأكيد نجاح التوافق مع متطلبات ZATCA (BT-110/112).

<img width="1130" height="463" alt="image" src="https://github.com/user-attachments/assets/5d857f09-0bff-4dd8-9348-6482561e47cb" />

