### PR TITLE
Fix Phase 1 validation when Phase 2 settings are revoked

### DIFF
--- a/ksa_compliance/ksa_compliance/doctype/zatca_phase_1_business_settings/zatca_phase_1_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_phase_1_business_settings/zatca_phase_1_business_settings.py
@@ -25,7 +25,13 @@ class ZATCAPhase1BusinessSettings(Document):
     pass
 
     def validate(self):
-        business_settings_id = frappe.get_value('ZATCA Business Settings', {'company': self.company})
+        business_settings_id = frappe.get_value(
+            'ZATCA Business Settings',
+            {
+                'company': self.company,
+                'status': 'Active',
+            },
+        )
         if business_settings_id and self.status == 'Active':
             link = get_link_to_form('ZATCA Business Settings', business_settings_id)
             frappe.throw(


### PR DESCRIPTION
- filter the Phase 2 lookup by status so only active records block Phase 1 activation
- ensure users can enable Phase 1 settings after revoking their Phase 2 configuration