### PR TITLE
fix: handle None zatca_category by casting to string

### DIFF
--- a/ksa_compliance/output_models/tax.py
+++ b/ksa_compliance/output_models/tax.py
@@ -48,7 +48,7 @@ def create_tax_categories(doc: SalesInvoice | PaymentEntry, item_lines: list, is
             row.tax_category = dataclass_to_frappe_dict(tax_category)
         tax_category_by_items = TaxCategoryByItems(tax_category=tax_category, items=[row for row in item_lines])
         tax_category_by_items_cls = tax_category_map.setdefault(
-            zatca_category + str(tax_category_percent), tax_category_by_items
+            str(zatca_category) + str(tax_category_percent), tax_category_by_items
         )
         return tax_category_map
 
@@ -72,6 +72,7 @@ def create_tax_categories(doc: SalesInvoice | PaymentEntry, item_lines: list, is
             zatca_category = frappe.db.get_value(
                 'Item Tax Template', row.item_tax_template, 'custom_zatca_item_tax_category'
             )
+        
         tax_category = TaxCategory(
             zatca_tax_category_id=tax_category_id, percent=tax_category_percent, tax_scheme_id='VAT'
         )
@@ -79,7 +80,7 @@ def create_tax_categories(doc: SalesInvoice | PaymentEntry, item_lines: list, is
         row.tax_category = dataclass_to_frappe_dict(tax_category)
         tax_category_by_items = TaxCategoryByItems(tax_category=tax_category, items=[])
         tax_category_by_items_cls = tax_category_map.setdefault(
-            zatca_category + str(tax_category_percent), tax_category_by_items
+            str(zatca_category) + str(tax_category_percent), tax_category_by_items
         )
         tax_category_by_items_cls.items.append(row)
     return tax_category_map


### PR DESCRIPTION
## Description
Fixes `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` when submitting sales invoices with missing ZATCA category configuration.

## Problem
When submitting a sales invoice, if the `custom_zatca_category` field is not set on the Tax Category or `custom_zatca_item_tax_category` is not set on the Item Tax Template, the system throws a TypeError during tax category mapping:

TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
File "ksa_compliance/output_models/tax.py", line 82, in create_tax_categories
zatca_category + str(tax_category_percent), tax_category_by_items

[Screencast from 2025-12-23 13-08-37.webm](https://github.com/user-attachments/assets/bbd0513c-9de0-4830-83fc-98e35bec1f49)


## Solution
Cast `zatca_category` to string before concatenation to handle `None` values gracefully. This allows the system to continue processing invoices even when ZATCA category fields are not configured, using `"None"` as the key in the tax category map.

## Changes
- Cast `zatca_category` to string in both locations where it's concatenated with `tax_category_percent`
- Line 51: `str(zatca_category) + str(tax_category_percent)`
- Line 83: `str(zatca_category) + str(tax_category_percent)`

## Testing
Tested with sales invoice submission where Tax Category `custom_zatca_category` field was not set. Invoice now submits successfully without the TypeError.
