### PR TITLE
fix for ZATCA BR-CO-11 and BR-KSA-F-04 validation error

### DIFF
--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -932,7 +932,7 @@ class Einvoice:
             flt(row['amount'], 2) for row in self.result['invoice']['allowance_charge']
         )
 
-        self.result['invoice']['net_total'] = (
+        self.result['invoice']['net_total'] = abs(
             self.result['invoice']['line_extension_amount'] - self.result['invoice']['allowance_total_amount']
         )
         if self.sales_invoice_doc.doctype == 'Payment Entry':
@@ -947,8 +947,8 @@ class Einvoice:
         if self.sales_invoice_doc.doctype != 'Payment Entry':
             rounding_adjustment = self.sales_invoice_doc.rounding_adjustment
 
-        self.result['invoice']['payable_amount'] = self.result['invoice']['grand_total'] + rounding_adjustment
-        self.result['invoice']['rounding_adjustment'] = rounding_adjustment
+        self.result['invoice']['payable_amount'] = abs(self.result['invoice']['grand_total'] + rounding_adjustment)
+        self.result['invoice']['rounding_adjustment'] = abs(rounding_adjustment)
 
         if self.sales_invoice_doc.doctype == 'Payment Entry':
             return

--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -924,6 +924,14 @@ class Einvoice:
         self.result['invoice']['item_lines'] = item_lines
         self.result['invoice']['line_extension_amount'] = sum(it['amount'] for it in item_lines)
         self.compute_invoice_discount_amount()
+
+        # To avoid rejection code: BR-CO-11
+        # Rejection message: Sum of allowances on document level (BT-107) = Σ Document level allowance amount (BT-92)
+        # We need to ensure that the total document level allowance amount is equal to the sum of all document level allowance amounts.
+        self.result['invoice']['allowance_total_amount'] = sum(
+            flt(row['amount'], 2) for row in self.result['invoice']['allowance_charge']
+        )
+
         self.result['invoice']['net_total'] = (
             self.result['invoice']['line_extension_amount'] - self.result['invoice']['allowance_total_amount']
         )

--- a/ksa_compliance/output_models/tax.py
+++ b/ksa_compliance/output_models/tax.py
@@ -146,7 +146,7 @@ def create_allowance_charge(doc: SalesInvoice | PaymentEntry, tax_total: frappe.
             charge_indicator='false',
             allowance_charge_reason=discount_reason,
             allowance_charge_reason_code=discount_reason_code,
-            amount=row.total_discount,
+            amount=abs(row.total_discount),
         )
         allowance_charges.append(dataclass_to_frappe_dict(allowance_charge))
     return allowance_charges


### PR DESCRIPTION
I have fixed the ZATCA BR-CO-11 and BR-KSA-F-04  validation error. The fix ensures that the document-level allowance total always matches the sum of its individual components, which was the cause of the rejection.