### PR TITLE
feat: fall back to Business Settings seller IDs when branch has no CRN

### DIFF
--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -445,25 +445,30 @@ class Einvoice:
     def get_business_settings_and_seller_details(self):
         # TODO: special validations handling
         has_branch_address = False
-        if self.branch_doc:
+        branch_has_crn = (
+            self.branch_doc
+            and getattr(self.branch_doc, 'custom_branch_ids', None)
+            and any(
+                strip(row.value) for row in self.branch_doc.custom_branch_ids if hasattr(row, 'value')
+            )
+        )
+
+        if self.branch_doc and branch_has_crn:
+            # Branch has its own CRN — use branch seller IDs
             if self.branch_doc.custom_company_address:
                 has_branch_address = True
 
-            party_identification = self.get_list_value(
+            self.get_list_value(
                 field_name='custom_branch_ids',
                 source_doc=self.branch_doc,
                 xml_name='party_identifications',
                 parent='seller_details',
             )
-            if not party_identification:
-                fthrow(
-                    msg=ft(
-                        'Commercial registration number is mandatory for branch $branch.',
-                        branch=self.sales_invoice_doc.branch,
-                    ),
-                    title=ft('Mandatory CRN Error'),
-                )
         else:
+            # No branch or branch without its own CRN — fall back to Business Settings seller IDs
+            if self.branch_doc and self.branch_doc.custom_company_address:
+                has_branch_address = True
+
             self.get_list_value(
                 field_name='other_ids',
                 source_doc=self.business_settings_doc,

--- a/ksa_compliance/standard_doctypes/branch.py
+++ b/ksa_compliance/standard_doctypes/branch.py
@@ -10,6 +10,14 @@ def validate_branch(doc, method):
 
 
 def validate_mandatory_crn(doc):
+    """Validate CRN when present on a branch.
+
+    When branch configuration is enabled, branches may optionally specify their own CRN
+    via ``custom_branch_ids``. If a branch does not have a CRN, invoices for that branch
+    will fall back to the seller IDs from ZATCA Business Settings. This supports the
+    common scenario where most branches share the company's main Commercial Registration
+    while only specific branches operate under a different one.
+    """
     if (
         doc.custom_branch_ids
         and doc.custom_company


### PR DESCRIPTION
## Summary

When **Enable Branch Configuration** is checked in ZATCA Business Settings, the current code requires every branch to have its own CRN in `custom_branch_ids`. This creates a problem for a common real-world scenario:

**Scenario:** A company has multiple branches (e.g., 7 branches), but only **one branch** operates under a different Commercial Registration (CR). The remaining branches all share the company's main CR from ZATCA Business Settings.

**Current behavior:**
- Branches without CRN → error: *"Commercial registration number is mandatory for branch"*
- Branches cannot share the same CRN → blocked by duplicate CRN validation
- Users are forced to either disable branch configuration entirely or cannot proceed

**New behavior:**
- Branch **with** its own CRN in `custom_branch_ids` → uses branch's seller IDs (unchanged)
- Branch **without** CRN → falls back to `other_ids` from ZATCA Business Settings
- Branch address fallback is preserved — if a branch has `custom_company_address` set, its address fields are used regardless of CRN source

## Changes

- **`e_invoice_output_model.py`**: Instead of throwing an error when a branch has no CRN, fall back to Business Settings `other_ids`. Added `branch_has_crn` check that inspects whether any non-empty CRN value exists in the branch's `custom_branch_ids`.
- **`branch.py`**: Added docstring to `validate_mandatory_crn` clarifying that branches may optionally specify their own CRN, with fallback to Business Settings for branches that don't.

## Example

| Branch | Has own CRN? | Seller IDs source |
|--------|-------------|-------------------|
| KENZ BURGER | Yes (own CRN) | Branch `custom_branch_ids` |
| FUROOJ 1 | No | ZATCA Business Settings `other_ids` |
| FUROOJ 2 | No | ZATCA Business Settings `other_ids` |
| ELECTRIC1 | No | ZATCA Business Settings `other_ids` |

## Test plan

- [ ] Create ZATCA Business Settings with branch config enabled and seller IDs populated
- [ ] Branch WITH its own CRN → verify invoice uses the branch's CRN
- [ ] Branch WITHOUT CRN → verify invoice falls back to Business Settings seller IDs
- [ ] Verify branch address fields still work correctly for both scenarios
- [ ] Verify duplicate CRN validation still works for branches that do have CRN