### PR TITLE
fix: prevent batch sync racing with live ZATCA submission

### DIFF
--- a/ksa_compliance/background_jobs.py
+++ b/ksa_compliance/background_jobs.py
@@ -2,7 +2,9 @@ import datetime
 from typing import Optional, cast
 
 import frappe
+import frappe.utils.background_jobs
 from frappe.query_builder import DocType
+from frappe.utils import add_to_date, now_datetime
 from pypika import Order
 from pypika.queries import QueryBuilder
 from result import is_ok
@@ -11,6 +13,53 @@ from ksa_compliance import logger
 from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales_invoice_additional_fields import (
     SalesInvoiceAdditionalFields,
 )
+from ksa_compliance.ksa_compliance.doctype.zatca_business_settings.zatca_business_settings import (
+    ZATCABusinessSettings,
+)
+from ksa_compliance.ksa_compliance.doctype.zatca_egs.zatca_egs import ZATCAEGS
+from ksa_compliance.zatca_live_sync import get_live_zatca_submit_job_id
+
+LIVE_SYNC_BATCH_GRACE_SECONDS = 60
+
+
+def _is_live_sync_for_siaf(row: dict) -> bool:
+    settings = ZATCABusinessSettings.for_invoice(row.get('sales_invoice'), row.get('invoice_doctype'))
+    if not settings:
+        return False
+
+    is_live_sync = settings.is_live_sync
+    if row.get('precomputed_invoice'):
+        device_id = frappe.db.get_value('ZATCA Precomputed Invoice', row.precomputed_invoice, 'device_id')
+        if device_id:
+            egs_settings = ZATCAEGS.for_device(device_id)
+            if egs_settings:
+                is_live_sync = egs_settings.is_live_sync
+    return is_live_sync
+
+
+def should_skip_live_batch_submission(siaf_name: str) -> str | None:
+    """Return skip reason for live sync, or None to proceed with batch submit."""
+    row = frappe.db.get_value(
+        'Sales Invoice Additional Fields',
+        siaf_name,
+        ['integration_status', 'creation', 'sales_invoice', 'invoice_doctype', 'precomputed_invoice'],
+        as_dict=True,
+    )
+    if not row or row.integration_status != 'Ready For Batch':
+        return None
+
+    if not _is_live_sync_for_siaf(row):
+        return None
+
+    job_id = get_live_zatca_submit_job_id(siaf_name)
+    if frappe.utils.background_jobs.is_job_enqueued(job_id):
+        return f'live RQ job active ({job_id})'
+
+    grace_cutoff = add_to_date(now_datetime(), seconds=-LIVE_SYNC_BATCH_GRACE_SECONDS)
+    if row.creation and row.creation > grace_cutoff:
+        return f'within {LIVE_SYNC_BATCH_GRACE_SECONDS}s grace period (creation={row.creation})'
+
+    return None
 
 
 @frappe.whitelist()
@@ -64,6 +113,11 @@ def sync_e_invoices(
 
         for doc in additional_field_docs:
             try:
+                skip_reason = should_skip_live_batch_submission(doc.name)
+                if skip_reason:
+                    logger.info(f'{prefix}Skipping {doc.name} — {skip_reason}')
+                    continue
+
                 logger.info(f'{prefix}Submitting {doc.name}')
                 if dry_run:
                     continue

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -27,6 +27,7 @@ from result import is_err, Result, Err, Ok, is_ok
 
 from ksa_compliance import SALES_INVOICE_CODE, DEBIT_NOTE_CODE, CREDIT_NOTE_CODE, PREPAYMENT_INVOICE_CODE
 from ksa_compliance import logger
+from ksa_compliance.zatca_live_sync import get_live_zatca_submit_job_id
 from ksa_compliance import zatca_api as api
 from ksa_compliance import zatca_cli as cli
 from ksa_compliance.generate_xml import generate_xml_file
@@ -640,7 +641,12 @@ def fix_rejection(id: str):
     new_siaf.insert(ignore_permissions=True)
 
     if settings.is_live_sync:
-        frappe.utils.background_jobs.enqueue(_submit_additional_fields, doc=new_siaf, enqueue_after_commit=True)
+        frappe.utils.background_jobs.enqueue(
+            _submit_additional_fields,
+            doc=new_siaf,
+            enqueue_after_commit=True,
+            job_id=get_live_zatca_submit_job_id(new_siaf.name),
+        )
 
     frappe.msgprint(ft('Created $link', link=get_link_to_form('Sales Invoice Additional Fields', new_siaf.name)))
 

--- a/ksa_compliance/standard_doctypes/payment_entry/payment_entry.py
+++ b/ksa_compliance/standard_doctypes/payment_entry/payment_entry.py
@@ -9,6 +9,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import PaymentEntry
 
 
 from ksa_compliance import logger
+from ksa_compliance.zatca_live_sync import get_live_zatca_submit_job_id
 from ksa_compliance.throw import fthrow
 from ksa_compliance.translation import ft
 
@@ -66,7 +67,10 @@ def create_prepayment_invoice_additional_fields_doctype(self: PaymentEntry, meth
         # We're running in the context of invoice submission (on_submit hook). We only want to run our ZATCA logic if
         # the invoice submits successfully after on_submit is run successfully from all apps.
         frappe.utils.background_jobs.enqueue(
-            _submit_additional_fields, doc=prepayment_additional_fields_doc, enqueue_after_commit=True
+            _submit_additional_fields,
+            doc=prepayment_additional_fields_doc,
+            enqueue_after_commit=True,
+            job_id=get_live_zatca_submit_job_id(prepayment_additional_fields_doc.name),
         )
 
 

--- a/ksa_compliance/standard_doctypes/sales_invoice.py
+++ b/ksa_compliance/standard_doctypes/sales_invoice.py
@@ -24,6 +24,7 @@ from ksa_compliance.ksa_compliance.doctype.zatca_precomputed_invoice.zatca_preco
 )
 
 from ksa_compliance.translation import ft
+from ksa_compliance.zatca_live_sync import get_live_zatca_submit_job_id
 
 IGNORED_INVOICES = set()
 
@@ -83,7 +84,10 @@ def create_sales_invoice_additional_fields_doctype(self: SalesInvoice | POSInvoi
         # We're running in the context of invoice submission (on_submit hook). We only want to run our ZATCA logic if
         # the invoice submits successfully after on_submit is run successfully from all apps.
         frappe.utils.background_jobs.enqueue(
-            _submit_additional_fields, doc=si_additional_fields_doc, enqueue_after_commit=True
+            _submit_additional_fields,
+            doc=si_additional_fields_doc,
+            enqueue_after_commit=True,
+            job_id=get_live_zatca_submit_job_id(si_additional_fields_doc.name),
         )
 
 

--- a/ksa_compliance/zatca_live_sync.py
+++ b/ksa_compliance/zatca_live_sync.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026, LavaLoon and contributors
+# For license information, please see license.txt
+
+
+def get_live_zatca_submit_job_id(siaf_name: str) -> str:
+    """Stable RQ job id for a live ZATCA submission on one SIAF document."""
+    return f'zatca_submit_{siaf_name}'


### PR DESCRIPTION
**Target:** lavaloon-eg/ksa_compliance `develop`
**Head:** abdopcnet:fix/live-batch-zatca-race
**Compare:** https://github.com/lavaloon-eg/ksa_compliance/compare/develop...abdopcnet:ksa_compliance:fix/live-batch-zatca-race

---

fix: prevent batch sync racing with live ZATCA submission

---

## Summary

- Add stable live ZATCA submission `job_id` values per SIAF document
- Prevent batch sync from processing invoices already being handled by live sync
- Add a 60-second grace period for newly created live-sync SIAF documents
- Keep batch retry processing for `Resend` and `Corrected` documents unchanged
- Log skip reasons for expected live-versus-batch conflicts

## Problem

**Old:**

- Live sync and batch sync could submit the same SIAF document in parallel
- Batch sync processed `Ready For Batch` documents without checking live job status
- Newly created SIAF documents could be picked up by batch immediately after creation
- Parallel submissions could create duplicate integration log inserts

**New:**

- Live submissions use a predictable `job_id` based on the SIAF document
- Batch sync skips eligible documents when a live job is active
- Batch sync skips newly created live-sync documents during a 60-second grace period
- `Resend` and `Corrected` documents remain eligible for batch processing
- Worker logs record the specific reason for each skip decision

## Files changed

- `ksa_compliance/zatca_live_sync.py`
- `ksa_compliance/background_jobs.py`
- `ksa_compliance/standard_doctypes/sales_invoice.py`
- `ksa_compliance/standard_doctypes/payment_entry/payment_entry.py`
- `ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py`
