### PR TITLE
fix: reload SIAF in live ZATCA worker by doc_name

### DIFF
--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -672,6 +672,11 @@ def _get_integration_status(code: int) -> ZatcaIntegrationStatus:
 
 
 def _submit_additional_fields(doc: SalesInvoiceAdditionalFields):
+    current_modified = frappe.db.get_value('Sales Invoice Additional Fields', doc.name, 'modified')
+    if current_modified and str(current_modified) != str(doc.modified):
+        logger.info(f'Reloading {doc.name} because it was modified after enqueue')
+        doc.reload()
+
     logger.info(f'Submitting {doc.name}')
     result = doc.submit_to_zatca()
     message = result.ok_value if is_ok(result) else result.err_value

--- a/ksa_compliance/standard_doctypes/payment_entry/payment_entry.py
+++ b/ksa_compliance/standard_doctypes/payment_entry/payment_entry.py
@@ -71,6 +71,11 @@ def create_prepayment_invoice_additional_fields_doctype(self: PaymentEntry, meth
 
 
 def _submit_additional_fields(doc: SalesInvoiceAdditionalFields):
+    current_modified = frappe.db.get_value('Sales Invoice Additional Fields', doc.name, 'modified')
+    if current_modified and str(current_modified) != str(doc.modified):
+        logger.info(f'Reloading {doc.name} because it was modified after enqueue')
+        doc.reload()
+
     logger.info(f'Submitting {doc.name}')
     result = doc.submit_to_zatca()
     message = result.ok_value if is_ok(result) else result.err_value

--- a/ksa_compliance/standard_doctypes/sales_invoice.py
+++ b/ksa_compliance/standard_doctypes/sales_invoice.py
@@ -88,6 +88,11 @@ def create_sales_invoice_additional_fields_doctype(self: SalesInvoice | POSInvoi
 
 
 def _submit_additional_fields(doc: SalesInvoiceAdditionalFields):
+    current_modified = frappe.db.get_value('Sales Invoice Additional Fields', doc.name, 'modified')
+    if current_modified and str(current_modified) != str(doc.modified):
+        logger.info(f'Reloading {doc.name} because it was modified after enqueue')
+        doc.reload()
+
     logger.info(f'Submitting {doc.name}')
     result = doc.submit_to_zatca()
     message = result.ok_value if is_ok(result) else result.err_value


### PR DESCRIPTION
**Target:** abdopcnet/ksa_compliance `fix/live-batch-zatca-race`
**Head:** abdopcnet:fix/live-siaf-doc-name-worker
**Compare:** https://github.com/abdopcnet/ksa_compliance/compare/fix/live-batch-zatca-race...fix/live-siaf-doc-name-worker

---

fix: reload stale SIAF docs only when needed in live worker

---

## Summary

- Keep live worker fast by avoiding unconditional SIAF reload on every job run
- Compare current database `modified` timestamp with enqueued document timestamp
- Reload SIAF only when the row changed after enqueue
- Prevent `TimestampMismatchError` while preserving common-path performance
- Apply the same stale-check pattern in Sales Invoice, Payment Entry, and `fix_rejection` worker path

## Problem

**Old:**

- Worker always used the enqueued in-memory SIAF document instance
- If SIAF changed after enqueue, `submit_to_zatca()` could fail on save with `TimestampMismatchError`
- A full reload approach fixes this but adds unnecessary DB reads in the common case

**New:**

- Worker checks `modified` from DB before submit and compares with `doc.modified`
- Worker reloads the same document with `doc.reload()` only when timestamps differ
- Common path stays fast, while stale-document path becomes safe

## Files changed

- `ksa_compliance/standard_doctypes/sales_invoice.py`
- `ksa_compliance/standard_doctypes/payment_entry/payment_entry.py`
- `ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py`
