### PR TITLE
fix: ignore_permissions on ZATCA SIAF save, submit, and fix_rejection

### DIFF
--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -314,8 +314,10 @@ class SalesInvoiceAdditionalFields(Document):
             signed_xml, self.invoice_hash, invoice_type, settings.fatoora_server_url, token, secret
         )
 
-        # Regardless of what happened, save the side effects of the API call
-        self.save()
+        # Regardless of what happened, save the side effects of the API call.
+        # Background jobs run as the invoice submitter; they often lack Write/Submit
+        # on this DocType while still being allowed to post Sales Invoice.
+        self.save(ignore_permissions=True)
 
         # Resend means we keep ourselves as draft to be picked up by the next run of the background job
         if integration_status == 'Resend':
@@ -326,6 +328,9 @@ class SalesInvoiceAdditionalFields(Document):
         else:
             # Any case other than resend is submitted
             self.allow_submit = 1
+            # Document.submit() takes no kwargs in this Frappe version; use flags
+            # so the inner save() skips permission checks (same as save(ignore_permissions=True)).
+            self.flags.ignore_permissions = True
             self.submit()
 
         return Ok(f'Invoice sent to ZATCA. Integration status: {integration_status}')
@@ -632,7 +637,7 @@ def fix_rejection(id: str):
         fthrow(ft('Missing ZATCA business settings for sales invoice: $invoice', invoice=siaf.sales_invoice))
 
     new_siaf = SalesInvoiceAdditionalFields.create_for_invoice(siaf.sales_invoice, siaf.invoice_doctype)
-    new_siaf.insert()
+    new_siaf.insert(ignore_permissions=True)
 
     if settings.is_live_sync:
         frappe.utils.background_jobs.enqueue(_submit_additional_fields, doc=new_siaf, enqueue_after_commit=True)


### PR DESCRIPTION
**Target:** lavaloon-eg/ksa_compliance `develop`
**Head:** abdopcnet:fix/siaf-ignore-permissions
**Compare:** https://github.com/lavaloon-eg/ksa_compliance/compare/develop...abdopcnet:ksa_compliance:fix/siaf-ignore-permissions


---

## Summary

- Allow background ZATCA workers to save SIAF updates without user Write permission
- Allow background ZATCA workers to submit SIAF after successful integration without user Submit permission
- Allow `fix_rejection` to insert a replacement SIAF without user Create permission
- Standalone change on `develop` — only `sales_invoice_additional_fields.py`, no dependency on other PRs
- Defensive permission bypass for batch sync paths that reload SIAF via `get_doc()`

## Problem

**Old:**

- `submit_to_zatca()` called `self.save()` with normal permission checks
- `submit_to_zatca()` called `self.submit()` with normal permission checks
- `fix_rejection` called `new_siaf.insert()` with normal permission checks
- Users who can submit Sales Invoice often lack SIAF Write, Submit, or Create permissions
- ZATCA could accept an invoice while local SIAF save or submit failed with `PermissionError`

**New:**

- `submit_to_zatca()` uses `self.save(ignore_permissions=True)` after ZATCA API processing
- `submit_to_zatca()` sets `self.flags.ignore_permissions = True` before `self.submit()`
- `fix_rejection` uses `new_siaf.insert(ignore_permissions=True)`
- Background processing completes regardless of SIAF role permissions on the submitting user

## Files changed

- `ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py`
