### PR TITLE
fix: open ZATCA integration reports from workspace as query reports

### DIFF
--- a/ksa_compliance/ksa_compliance/workspace/zatca/zatca.json
+++ b/ksa_compliance/ksa_compliance/workspace/zatca/zatca.json
@@ -181,24 +181,22 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Zatca Integration Details",
    "link_count": 0,
    "link_to": "Zatca Integration Details",
    "link_type": "Report",
    "onboard": 0,
-   "report_ref_doctype": "Sales Invoice",
    "type": "Link"
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Zatca Integration Summary",
    "link_count": 0,
    "link_to": "Zatca Integration Summary",
    "link_type": "Report",
    "onboard": 0,
-   "report_ref_doctype": "Sales Invoice",
    "type": "Link"
   }
  ],


### PR DESCRIPTION
**Target:** lavaloon-eg/ksa_compliance `develop`
**Head:** abdopcnet:fix/zatca-workspace-report-links
**Compare:** https://github.com/lavaloon-eg/ksa_compliance/compare/develop...abdopcnet:ksa_compliance:fix/zatca-workspace-report-links

---

## Summary

- Fix workspace shortcuts for **Zatca Integration Details** and **Zatca Integration Summary**
- Open both as Script Reports via Query Report route

## Problem

**Old:**

- `is_query_report: 0` on both ZATCA report workspace links
- `report_ref_doctype: "Sales Invoice"` on both links
- Route opened `/app/sales-invoice/view/report/...` (Report View)
- Script reports could fail with blank page and `JSON.parse` errors

**New:**

- `is_query_report: 1` on both ZATCA report workspace links
- `report_ref_doctype` removed from both links
- Route opens `/app/query-report/...` (Query Report)
- Script reports open correctly from the ZATCA workspace

## Files changed

- `ksa_compliance/ksa_compliance/workspace/zatca/zatca.json`
