### PR TITLE
fix: enhance ZATCA integration summary and details reports

### DIFF
--- a/ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.js
+++ b/ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.js
@@ -1,42 +1,120 @@
 // Copyright (c) 2024, LavaLoon and contributors
 // For license information, please see license.txt
 
-frappe.query_reports["Zatca Integration Details"] = {
-	"onload": function (report) {
-    const summary_elm = document.getElementById('message-summary')
-    if (!summary_elm) {
-      const page_container = report.$page[0];
-      const filters_section = page_container.querySelector(".page-form");
-      const message = "This report will display the ZATCA status for each transaction and provide detailed invoice amount information, to reconcile transactions between the system and Fatoorah platform.\n" +
-          "It is not recommended to run or generate this report with the “From Date” and “To Date” filters set for a period exceeding 31 days.";
+frappe.query_reports['Zatca Integration Details'] = {
+	filters: [
+		{
+			fieldname: 'from_date_filter',
+			label: __('From Date'),
+			fieldtype: 'Date',
+			default: frappe.datetime.month_start(),
+			reqd: 1,
+		},
+		{
+			fieldname: 'to_date_filter',
+			label: __('To Date'),
+			fieldtype: 'Date',
+			default: frappe.datetime.now_date(),
+			reqd: 1,
+		},
+		{
+			fieldname: 'company_filter',
+			label: __('Company'),
+			fieldtype: 'Link',
+			options: 'Company',
+			default: frappe.defaults.get_user_default('Company'),
+			reqd: 1,
+		},
+		{
+			fieldname: 'branch_filter',
+			label: __('Branch'),
+			fieldtype: 'Link',
+			options: 'Branch',
+		},
+		{
+			fieldname: 'integration_status_filter',
+			label: __('Integration Status'),
+			fieldtype: 'Select',
+			options:
+				'All\nReady For Batch\nResend\nAccepted with warnings\nAccepted\nRejected\nClearance switched off\nNot Sended\nNo Sales Invoice',
+			default: 'All',
+			reqd: 1,
+		},
+		{
+			fieldname: 'invoice_doctype',
+			label: __('Document Type'),
+			fieldtype: 'Select',
+			options: 'All\nSales Invoice\nPOS Invoice\nPayment Entry',
+			default: 'All',
+			reqd: 1,
+		},
+		{
+			fieldname: 'validated_filter',
+			label: __('Date Validation'),
+			fieldtype: 'Select',
+			options: 'All\nValidated\nNot Validated',
+			default: 'All',
+			reqd: 1,
+		},
+	],
 
-      const message_summary_elm = document.createElement('div');
-      message_summary_elm.classList.add('my-3', 'mx-auto');
-      message_summary_elm.id = 'message-summary';
-      message_summary_elm.style.width = '95%';
+	onload: function (report) {
+		const summary_elm = document.getElementById('message-summary');
+		if (summary_elm) {
+			return;
+		}
 
-      const message_title = document.createElement('h5');
-      message_title.innerText = 'Summary';
-      const message_content = document.createElement('span');
-      message_content.innerText = message;
+		const page_container = report.$page && report.$page[0];
+		if (!page_container) {
+			return;
+		}
 
-      message_summary_elm.append(document.createElement('hr'), message_title, message_content);
-      filters_section.appendChild(message_summary_elm);
-    }
-  },
-    formatter:function (value, row, column, data, default_formatter) {
-    value = default_formatter(value, row, column, data);
-    if (column.fieldname == 'integration_status') {
-       if (value.toLowerCase() =='accepted') {
-            value = `<b style="color:green">${value}</b>`
-       } else if (value.toLowerCase() == 'rejected') {
-            value = `<b style="color:red">${value}</b>`
-       } else if (value.toLowerCase() == 'resend') {
-            value = `<b style="color:blue">${value}</b>`
-       } else if (value.toLowerCase() == 'accepted with warnings') {
-            value = `<b style="color:orange">${value}</b>`
-       }
-    }
-    return value;
-}
+		const filters_section = page_container.querySelector('.page-form');
+		if (!filters_section) {
+			return;
+		}
+
+		const message =
+			'This report will display the ZATCA status for each transaction and provide detailed invoice amount information, to reconcile transactions between the system and Fatoorah platform.\n' +
+			'It is not recommended to run or generate this report with the "From Date" and "To Date" filters set for a period exceeding 31 days.';
+
+		const message_summary_elm = document.createElement('div');
+		message_summary_elm.classList.add('my-3', 'mx-auto');
+		message_summary_elm.id = 'message-summary';
+		message_summary_elm.style.width = '95%';
+
+		const message_title = document.createElement('h5');
+		message_title.innerText = 'Summary';
+		const message_content = document.createElement('span');
+		message_content.innerText = message;
+
+		message_summary_elm.append(
+			document.createElement('hr'),
+			message_title,
+			message_content,
+		);
+		filters_section.appendChild(message_summary_elm);
+	},
+
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (!value || column.fieldname !== 'integration_status') {
+			return value;
+		}
+
+		const status = String(value).toLowerCase();
+		if (status === 'accepted') {
+			return `<b style="color:green">${value}</b>`;
+		}
+		if (status === 'rejected') {
+			return `<b style="color:red">${value}</b>`;
+		}
+		if (status === 'resend') {
+			return `<b style="color:blue">${value}</b>`;
+		}
+		if (status === 'accepted with warnings') {
+			return `<b style="color:orange">${value}</b>`;
+		}
+		return value;
+	},
 };

--- a/ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.py
+++ b/ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.py
@@ -3,31 +3,27 @@
 
 import frappe
 from frappe import _
-from datetime import datetime
+from frappe.utils import getdate
 
 
 def execute(filters=None):
-    columns, data, chart, report_summary = [], [], None, []
-    if not filters:
-        return
+    columns = get_columns()
+    filters = _normalize_filters(filters)
 
-    df = datetime.strptime(filters['from_date_filter'], '%Y-%m-%d')
-    dt = datetime.strptime(filters['to_date_filter'], '%Y-%m-%d')
-    if dt < df:
-        frappe.throw(
-            msg="""To date must be after From date.
-                        error_code='InvalidDateRange',
-                        code=400
-                        """
-        )
+    if not filters.get('company_filter'):
+        return columns, [], None, None, []
+
+    if getdate(filters['to_date_filter']) < getdate(filters['from_date_filter']):
+        frappe.throw(_('To Date must be on or after From Date'))
+
     try:
         data = get_zatca_integration_details_data(filters=filters)
-        columns = get_columns()
+        data = apply_status_filter(data, filters.get('integration_status_filter'))
         records_count = len(data)
         report_summary = [
             {
                 'value': records_count,
-                'label': 'Number of records',
+                'label': _('Number of records'),
                 'datatype': 'Number',
             },
         ]
@@ -36,12 +32,10 @@ def execute(filters=None):
         labels = []
         colors = []
         for row in data:
-            if row['integration_status'] not in labels:
-                labels.append(row['integration_status'])
-            if row['integration_status'] not in values:
-                values[row['integration_status']] = 1
-            else:
-                values[row['integration_status']] += 1
+            status = row.get('integration_status')
+            if status not in labels:
+                labels.append(status)
+            values[status] = values.get(status, 0) + 1
 
         for label in labels:
             if label == 'Accepted':
@@ -52,96 +46,323 @@ def execute(filters=None):
                 colors.append('blue')
             elif label == 'Accepted with warnings':
                 colors.append('yellow')
-        chart = get_pie_chart_data(
-            title='Zatca Integration Status', labels=labels, values=values, height=250, colors=colors
+
+        chart = (
+            get_pie_chart_data(
+                title='Zatca Integration Status',
+                labels=labels,
+                values=values,
+                height=250,
+                colors=colors,
+            )
+            if labels
+            else None
         )
 
-        # return columns, data, message, chart, report_summary, primitive_summary
         return columns, data, None, chart, report_summary
 
-    except Exception as ex:
-        frappe.throw(msg=f"""{str(ex)}""")
+    except frappe.ValidationError:
+        raise
+    except Exception:
+        frappe.log_error(
+            title='[[zatca_integration_details.py]] - execute - body',
+            message=frappe.get_traceback(),
+        )
+        frappe.throw(_('Error running Zatca Integration Details report'))
+
+
+def _normalize_filters(filters):
+    """Apply safe defaults so the report can open before filters are submitted."""
+    filters = frappe._dict(filters or {})
+    filters.from_date_filter = filters.get('from_date_filter') or frappe.datetime.month_start()
+    filters.to_date_filter = filters.get('to_date_filter') or frappe.datetime.now_date()
+    filters.company_filter = filters.get('company_filter') or frappe.defaults.get_user_default('Company')
+    filters.integration_status_filter = filters.get('integration_status_filter') or 'All'
+    filters.invoice_doctype = filters.get('invoice_doctype') or 'All'
+    filters.validated_filter = filters.get('validated_filter') or 'All'
+    return filters
 
 
 def get_zatca_integration_details_data(filters):
-    query = """
-                SELECT 
-                    inv.name AS invoice_id,
-                    IFNULL(zi.integration_status,'N/A') integration_status,
-                    inv.posting_date,
-                    inv.net_total,
-                    inv.total_taxes_and_charges,
-                    inv.grand_total
-                FROM
-                    `tabSales Invoice Additional Fields` zi
-                RIGHT JOIN `tabSales Invoice` inv
-                ON inv.name = zi.sales_invoice
-                WHERE inv.company = %(company)s
-                AND inv.posting_date BETWEEN %(from_date)s AND DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
-                AND zi.is_latest = 1
-                AND (
-                (%(integration_status_filter)s = 'All' AND zi.integration_status IN ('All', 'Ready For Batch', 'Resend', 'Accepted with warnings', 'Accepted', 'Rejected', 'Clearance switched off'))
-                ) OR
-                (
-                (%(integration_status_filter)s != 'All' AND zi.integration_status = %(integration_status_filter)s)
-                )
-            """
+    data = []
+    if filters.get('invoice_doctype') in ('All', 'Sales Invoice'):
+        data.extend(get_sales_invoice_rows(filters))
+    if filters.get('invoice_doctype') in ('All', 'POS Invoice'):
+        data.extend(get_pos_invoice_rows(filters))
+    if filters.get('invoice_doctype') in ('All', 'Payment Entry'):
+        data.extend(get_payment_entry_rows(filters))
+    data = apply_validated_filter(data, filters.get('validated_filter'))
+    return data
 
-    return frappe.db.sql(
-        query=query,
-        values={
-            'from_date': filters['from_date_filter'],
-            'to_date': filters['to_date_filter'],
-            'company': filters['company_filter'],
-            'integration_status_filter': filters['integration_status_filter'],
-        },
-        as_dict=1,
+
+def apply_status_filter(rows, status_filter):
+    if not status_filter or status_filter == 'All':
+        return rows
+    return [row for row in rows if row.get('integration_status') == status_filter]
+
+
+def apply_validated_filter(rows, validated_filter):
+    if not validated_filter or validated_filter == 'All':
+        return rows
+    return [row for row in rows if row.get('validated') == validated_filter]
+
+
+def _get_common_values(filters):
+    values = {
+        'from_date': filters['from_date_filter'],
+        'to_date': filters['to_date_filter'],
+        'company': filters['company_filter'],
+    }
+    if filters.get('branch_filter'):
+        values['branch'] = filters['branch_filter']
+    return values
+
+
+def _get_branch_condition(filters, table_alias):
+    if not filters.get('branch_filter'):
+        return ''
+    if table_alias == 'inv':
+        return 'AND inv.branch = %(branch)s'
+    if table_alias == 'pos':
+        return 'AND pos.branch = %(branch)s'
+    return ''
+
+
+def _integration_status_case():
+    return """
+		CASE
+			WHEN zi.sales_invoice IS NULL THEN 'Not Sended'
+			WHEN IFNULL(zi.integration_status, '') = '' THEN 'No Sales Invoice'
+			ELSE zi.integration_status
+		END
+	"""
+
+
+def _validated_case():
+    return """
+		CASE
+			WHEN zi.last_attempt IS NULL THEN 'Not Validated'
+			WHEN DATE(base_doc.posting_date) = DATE(zi.last_attempt) THEN 'Validated'
+			ELSE 'Not Validated'
+		END
+	"""
+
+
+def get_sales_invoice_rows(filters):
+    branch_condition = _get_branch_condition(filters, 'inv')
+    query = (
+        """
+		SELECT
+			'Sales Invoice' AS invoice_doctype,
+			inv.name AS invoice_id,
+			"""
+        + _integration_status_case()
+        + """
+			 AS integration_status,
+			"""
+        + _validated_case()
+        + """
+			 AS validated,
+			inv.posting_date,
+			zi.last_attempt AS custom_zatca_siaf_date,
+			inv.branch,
+			inv.customer,
+			'Customer' AS party_doctype,
+			inv.net_total,
+			inv.total_taxes_and_charges,
+			inv.grand_total,
+			zi.name AS custom_zatca_siaf
+		FROM `tabSales Invoice` inv
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = inv.name
+			AND zi.invoice_doctype = 'Sales Invoice'
+			AND zi.is_latest = 1
+		LEFT JOIN `tabSales Invoice` base_doc
+			ON base_doc.name = inv.name
+		WHERE inv.company = %(company)s
+			AND inv.docstatus = 1
+			AND inv.posting_date BETWEEN %(from_date)s AND %(to_date)s
+			"""
+        + branch_condition
+        + """
+			AND NOT EXISTS (
+				SELECT 1
+				FROM `tabPOS Invoice` pos_map
+				WHERE pos_map.consolidated_invoice = inv.name
+			)
+	"""
     )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
+
+
+def get_pos_invoice_rows(filters):
+    branch_condition = _get_branch_condition(filters, 'pos')
+    query = (
+        """
+		SELECT
+			'POS Invoice' AS invoice_doctype,
+			pos.name AS invoice_id,
+			"""
+        + _integration_status_case()
+        + """
+			 AS integration_status,
+			"""
+        + _validated_case()
+        + """
+			 AS validated,
+			pos.posting_date,
+			zi.last_attempt AS custom_zatca_siaf_date,
+			pos.branch,
+			pos.customer,
+			'Customer' AS party_doctype,
+			pos.net_total,
+			pos.total_taxes_and_charges,
+			pos.grand_total,
+			zi.name AS custom_zatca_siaf
+		FROM `tabPOS Invoice` pos
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = pos.name
+			AND zi.invoice_doctype = 'POS Invoice'
+			AND zi.is_latest = 1
+		LEFT JOIN `tabPOS Invoice` base_doc
+			ON base_doc.name = pos.name
+		WHERE pos.company = %(company)s
+			AND pos.docstatus = 1
+			AND pos.posting_date BETWEEN %(from_date)s AND %(to_date)s
+			"""
+        + branch_condition
+        + """
+	"""
+    )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
+
+
+def get_payment_entry_rows(filters):
+    query = (
+        """
+		SELECT
+			'Payment Entry' AS invoice_doctype,
+			pe.name AS invoice_id,
+			"""
+        + _integration_status_case()
+        + """
+			 AS integration_status,
+			"""
+        + _validated_case()
+        + """
+			 AS validated,
+			pe.posting_date,
+			zi.last_attempt AS custom_zatca_siaf_date,
+			NULL AS branch,
+			pe.party AS customer,
+			pe.party_type AS party_doctype,
+			(pe.paid_amount - IFNULL(pe_tax.total_tax_amount, 0)) AS net_total,
+			IFNULL(pe_tax.total_tax_amount, 0) AS total_taxes_and_charges,
+			pe.paid_amount AS grand_total,
+			zi.name AS custom_zatca_siaf
+		FROM `tabPayment Entry` pe
+		LEFT JOIN (
+			SELECT parent, SUM(amount) AS total_tax_amount
+			FROM `tabPayment Entry Deduction`
+			GROUP BY parent
+		) pe_tax ON pe_tax.parent = pe.name
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = pe.name
+			AND zi.invoice_doctype = 'Payment Entry'
+			AND zi.is_latest = 1
+		LEFT JOIN `tabPayment Entry` base_doc
+			ON base_doc.name = pe.name
+		WHERE pe.company = %(company)s
+			AND pe.docstatus = 1
+			AND pe.custom_prepayment_invoice = 1
+			AND pe.posting_date BETWEEN %(from_date)s AND %(to_date)s
+	"""
+    )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
 
 
 def get_columns():
     return [
         {
-            'label': _('Invoice ID'),
+            'label': _('Document Type'),
+            'fieldname': 'invoice_doctype',
+            'fieldtype': 'Data',
+            'width': 140,
+        },
+        {
+            'label': _('Document'),
             'fieldname': 'invoice_id',
-            'fieldtype': 'Link',
-            'options': 'Sales Invoice',
+            'fieldtype': 'Dynamic Link',
+            'options': 'invoice_doctype',
             'width': 200,
         },
         {
             'label': _('ZATCA Integration Status'),
             'fieldname': 'integration_status',
             'fieldtype': 'Data',
-            'width': 200,
+            'width': 170,
+        },
+        {
+            'label': _('Date Validation'),
+            'fieldname': 'validated',
+            'fieldtype': 'Data',
+            'width': 140,
         },
         {
             'label': _('Posting Date'),
             'fieldname': 'posting_date',
             'fieldtype': 'Date',
-            'width': 200,
+            'width': 130,
+        },
+        {
+            'label': _('ZATCA Date'),
+            'fieldname': 'custom_zatca_siaf_date',
+            'fieldtype': 'Datetime',
+            'width': 185,
+        },
+        {
+            'label': _('Branch'),
+            'fieldname': 'branch',
+            'fieldtype': 'Link',
+            'options': 'Branch',
+            'width': 120,
+        },
+        {
+            'label': _('Customer'),
+            'fieldname': 'customer',
+            'fieldtype': 'Dynamic Link',
+            'options': 'party_doctype',
+            'width': 180,
         },
         {
             'label': _('Net Amount'),
             'fieldname': 'net_total',
             'fieldtype': 'Currency',
-            'width': 200,
+            'width': 130,
         },
         {
             'label': _('VAT Amount'),
             'fieldname': 'total_taxes_and_charges',
             'fieldtype': 'Currency',
-            'width': 200,
+            'width': 130,
         },
         {
             'label': _('Grand Total'),
             'fieldname': 'grand_total',
             'fieldtype': 'Currency',
-            'width': 200,
+            'width': 130,
+        },
+        {
+            'label': _('ZATCA SIAF'),
+            'fieldname': 'custom_zatca_siaf',
+            'fieldtype': 'Link',
+            'options': 'Sales Invoice Additional Fields',
+            'width': 220,
         },
     ]
 
 
-def get_pie_chart_data(title, labels: [], values: [], height=250, colors=None):
+def get_pie_chart_data(title, labels, values, height=250, colors=None):
     options = {
         'title': title,
         'data': {'labels': labels, 'datasets': [{'values': [values[label] for label in labels]}]},

--- a/ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.js
+++ b/ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.js
@@ -1,13 +1,55 @@
 // Copyright (c) 2024, LavaLoon and contributors
 // For license information, please see license.txt
 
-frappe.query_reports["Zatca Integration Summary"] = {
-	"onload": function (report) {
-		const summary_elm = document.getElementById('message-summary')
+frappe.query_reports['Zatca Integration Summary'] = {
+	filters: [
+		{
+			fieldname: 'from_date_filter',
+			label: __('From Date'),
+			fieldtype: 'Date',
+			default: frappe.datetime.month_start(),
+			reqd: 1,
+		},
+		{
+			fieldname: 'to_date_filter',
+			label: __('To Date'),
+			fieldtype: 'Date',
+			default: frappe.datetime.now_date(),
+			reqd: 1,
+		},
+		{
+			fieldname: 'company_filter',
+			label: __('Company'),
+			fieldtype: 'Link',
+			options: 'Company',
+			default: frappe.defaults.get_user_default('Company'),
+			reqd: 1,
+		},
+		{
+			fieldname: 'invoice_doctype',
+			label: __('Document Type'),
+			fieldtype: 'Select',
+			options: 'All\nSales Invoice\nPOS Invoice\nPayment Entry',
+			default: 'All',
+			reqd: 1,
+		},
+	],
+
+	onload: function (report) {
+		const summary_elm = document.getElementById('message-summary');
+		const page_container = report.$page && report.$page[0];
+		if (!page_container) {
+			return;
+		}
+
+		const filters_section = page_container.querySelector('.page-form');
+		if (!filters_section) {
+			return;
+		}
+
 		if (!summary_elm) {
-			const page_container = report.$page[0];
-			const filters_section = page_container.querySelector(".page-form");
-			const message = "A quick overview of ZATCA integration status totals and financial information is needed to monitor and reconcile transactions, ensuring all invoices are tracked and accounted for.";
+			const message =
+				'A quick overview of ZATCA integration status totals and financial information is needed to monitor and reconcile transactions, ensuring all invoices are tracked and accounted for.';
 
 			const message_summary_elm = document.createElement('div');
 			message_summary_elm.classList.add('my-3', 'mx-auto');
@@ -22,5 +64,15 @@ frappe.query_reports["Zatca Integration Summary"] = {
 			message_summary_elm.append(document.createElement('hr'), message_title, message_content);
 			filters_section.appendChild(message_summary_elm);
 		}
+
+		report.page.add_inner_button(__('Integration Details'), function () {
+			const v = report.get_values() || {};
+			frappe.set_route('query-report', 'Zatca Integration Details', {
+				from_date_filter: v.from_date_filter,
+				to_date_filter: v.to_date_filter,
+				company_filter: v.company_filter,
+				invoice_doctype: v.invoice_doctype || 'All',
+			});
+		});
 	},
 };

--- a/ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.py
+++ b/ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.py
@@ -1,81 +1,260 @@
 # Copyright (c) 2024, LavaLoon and contributors
 # For license information, please see license.txt
-from ksa_compliance.ksa_compliance.report.zatca_integration_details.zatca_integration_details import get_pie_chart_data
 
 import frappe
-from datetime import datetime
+from frappe import _
+from frappe.utils import getdate
+
+CANONICAL_STATUSES = (
+    'Ready For Batch',
+    'Resend',
+    'Accepted with warnings',
+    'Accepted',
+    'Rejected',
+    'Clearance switched off',
+    'Not Sended',
+    'No Sales Invoice',
+)
 
 
 def execute(filters=None):
-    data, chart, report_summary = [], None, []
+    columns = get_columns()
+    filters = _normalize_filters(filters)
 
-    if not filters:
-        return
+    if not filters.get('company_filter'):
+        return columns, [], None, None, []
 
-    df = datetime.strptime(filters['from_date_filter'], '%Y-%m-%d')
-    dt = datetime.strptime(filters['to_date_filter'], '%Y-%m-%d')
-    if dt < df:
-        frappe.throw(
-            msg=f"""Date range must be from {filters['from_date_filter']} to {filters['to_date_filter']}.
-                        error_code='InvalidDateRange',
-                        code=400
-                        """
+    if getdate(filters['to_date_filter']) < getdate(filters['from_date_filter']):
+        frappe.throw(_('To Date must be on or after From Date'))
+
+    try:
+        data = get_zatca_integration_summary_data(filters=filters)
+        chart = None
+        report_summary = []
+
+        if data:
+            labels = [row['integration_status'] for row in data]
+            values = {row['integration_status']: row['records_count'] for row in data}
+            chart = get_pie_chart_data(title='Zatca Integration Status', labels=labels, values=values)
+            records_count = sum(row['records_count'] for row in data)
+            report_summary = [
+                {
+                    'value': records_count,
+                    'label': _('Number of records'),
+                    'datatype': 'Number',
+                },
+            ]
+
+        return columns, data, None, chart, report_summary
+
+    except frappe.ValidationError:
+        raise
+    except Exception:
+        frappe.log_error(
+            title='[[zatca_integration_summary.py]] - execute - body',
+            message=frappe.get_traceback(),
         )
+        frappe.throw(_('Error running Zatca Integration Summary report'))
 
-    data = get_zatca_integration_summary_data(filters=filters)
 
-    if data:
-        labels = [row['integration_status'] for row in data]
-        values = {row['integration_status']: row['records_count'] for row in data}
-        chart = get_pie_chart_data(title='Zatca Integration Status', labels=labels, values=values)
-        records_count = sum(row['records_count'] for row in data)
-
-        report_summary = [
-            {
-                'value': records_count,
-                'label': 'Number of records',
-                'datatype': 'Number',
-            },
-        ]
-
-    # return columns, data, message, chart, report_summary, primitive_summary
-    return get_columns(), data, None, chart, report_summary
+def _normalize_filters(filters):
+    """Apply safe defaults so the report can open before filters are submitted."""
+    filters = frappe._dict(filters or {})
+    filters.from_date_filter = filters.get('from_date_filter') or frappe.datetime.month_start()
+    filters.to_date_filter = filters.get('to_date_filter') or frappe.datetime.now_date()
+    filters.company_filter = filters.get('company_filter') or frappe.defaults.get_user_default('Company')
+    filters.invoice_doctype = filters.get('invoice_doctype') or 'All'
+    return filters
 
 
 def get_columns():
     return [
-        {'fieldname': 'integration_status', 'fieldtype': 'Data', 'label': 'ZATCA Integration status', 'width': 200},
-        {'fieldname': 'records_count', 'fieldtype': 'Int', 'label': 'Total Number of invoices', 'width': 150},
-        {'fieldname': 'net_total', 'fieldtype': 'Currency', 'label': 'Net Total Amount', 'width': 150},
-        {'fieldname': 'total_taxes_and_charges', 'fieldtype': 'Currency', 'label': 'VAT Total Amount', 'width': 150},
-        {'fieldname': 'grand_total', 'fieldtype': 'Currency', 'label': 'Grand Total Amount', 'width': 150},
+        {
+            'fieldname': 'integration_status',
+            'fieldtype': 'Data',
+            'label': _('ZATCA Integration status'),
+            'width': 200,
+        },
+        {
+            'fieldname': 'records_count',
+            'fieldtype': 'Int',
+            'label': _('Total Number of invoices'),
+            'width': 150,
+        },
+        {
+            'fieldname': 'net_total',
+            'fieldtype': 'Currency',
+            'label': _('Net Total Amount'),
+            'width': 150,
+        },
+        {
+            'fieldname': 'total_taxes_and_charges',
+            'fieldtype': 'Currency',
+            'label': _('VAT Total Amount'),
+            'width': 150,
+        },
+        {
+            'fieldname': 'grand_total',
+            'fieldtype': 'Currency',
+            'label': _('Grand Total Amount'),
+            'width': 150,
+        },
     ]
 
 
 def get_zatca_integration_summary_data(filters):
-    query = """
-            SELECT IFNULL(zi.integration_status,'N/A') AS integration_status,
-            COUNT(DISTINCT inv.name) AS records_count,
-            SUM(inv.net_total) AS net_total,
-            SUM(inv.total_taxes_and_charges) AS total_taxes_and_charges,
-            SUM(inv.grand_total) AS grand_total
-            FROM
-            `tabSales Invoice` inv
-            LEFT JOIN `tabSales Invoice Additional Fields` zi
-            ON inv.name = zi.sales_invoice
-            WHERE inv.company = %(company)s
-            AND inv.docstatus = 1
-            AND inv.posting_date BETWEEN %(from_date)s AND DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
-            AND zi.is_latest = 1
-            GROUP BY zi.integration_status
-          """
+    rows = []
+    if filters.get('invoice_doctype') in ('All', 'Sales Invoice'):
+        rows.extend(get_sales_invoice_rows(filters))
+    if filters.get('invoice_doctype') in ('All', 'POS Invoice'):
+        rows.extend(get_pos_invoice_rows(filters))
+    if filters.get('invoice_doctype') in ('All', 'Payment Entry'):
+        rows.extend(get_payment_entry_rows(filters))
+    return build_summary_rows(aggregate_by_status(rows))
 
-    return frappe.db.sql(
-        query=query,
-        values={
-            'from_date': filters['from_date_filter'],
-            'to_date': filters['to_date_filter'],
-            'company': filters['company_filter'],
-        },
-        as_dict=1,
+
+def _get_common_values(filters):
+    return {
+        'from_date': filters['from_date_filter'],
+        'to_date': filters['to_date_filter'],
+        'company': filters['company_filter'],
+    }
+
+
+def _integration_status_case():
+    return """
+		CASE
+			WHEN zi.sales_invoice IS NULL THEN 'Not Sended'
+			WHEN IFNULL(zi.integration_status, '') = '' THEN 'No Sales Invoice'
+			ELSE zi.integration_status
+		END
+	"""
+
+
+def get_sales_invoice_rows(filters):
+    query = (
+        """
+		SELECT
+			"""
+        + _integration_status_case()
+        + """ AS integration_status,
+			1 AS records_count,
+			inv.net_total,
+			inv.total_taxes_and_charges,
+			inv.grand_total
+		FROM `tabSales Invoice` inv
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = inv.name
+			AND zi.invoice_doctype = 'Sales Invoice'
+			AND zi.is_latest = 1
+		WHERE inv.company = %(company)s
+			AND inv.docstatus = 1
+			AND inv.posting_date BETWEEN %(from_date)s AND %(to_date)s
+			AND NOT EXISTS (
+				SELECT 1
+				FROM `tabPOS Invoice` pos_map
+				WHERE pos_map.consolidated_invoice = inv.name
+			)
+	"""
     )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
+
+
+def get_pos_invoice_rows(filters):
+    query = (
+        """
+		SELECT
+			"""
+        + _integration_status_case()
+        + """ AS integration_status,
+			1 AS records_count,
+			pos.net_total,
+			pos.total_taxes_and_charges,
+			pos.grand_total
+		FROM `tabPOS Invoice` pos
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = pos.name
+			AND zi.invoice_doctype = 'POS Invoice'
+			AND zi.is_latest = 1
+		WHERE pos.company = %(company)s
+			AND pos.docstatus = 1
+			AND pos.posting_date BETWEEN %(from_date)s AND %(to_date)s
+	"""
+    )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
+
+
+def get_payment_entry_rows(filters):
+    query = (
+        """
+		SELECT
+			"""
+        + _integration_status_case()
+        + """ AS integration_status,
+			1 AS records_count,
+			(pe.paid_amount - IFNULL(pe_tax.total_tax_amount, 0)) AS net_total,
+			IFNULL(pe_tax.total_tax_amount, 0) AS total_taxes_and_charges,
+			pe.paid_amount AS grand_total
+		FROM `tabPayment Entry` pe
+		LEFT JOIN (
+			SELECT parent, SUM(amount) AS total_tax_amount
+			FROM `tabPayment Entry Deduction`
+			GROUP BY parent
+		) pe_tax ON pe_tax.parent = pe.name
+		LEFT JOIN `tabSales Invoice Additional Fields` zi
+			ON zi.sales_invoice = pe.name
+			AND zi.invoice_doctype = 'Payment Entry'
+			AND zi.is_latest = 1
+		WHERE pe.company = %(company)s
+			AND pe.docstatus = 1
+			AND pe.custom_prepayment_invoice = 1
+			AND pe.posting_date BETWEEN %(from_date)s AND %(to_date)s
+	"""
+    )
+    return frappe.db.sql(query, _get_common_values(filters), as_dict=1)
+
+
+def aggregate_by_status(rows):
+    aggregated = {}
+    for row in rows:
+        status = row.get('integration_status') or 'No Sales Invoice'
+        if status not in aggregated:
+            aggregated[status] = {
+                'integration_status': status,
+                'records_count': 0,
+                'net_total': 0,
+                'total_taxes_and_charges': 0,
+                'grand_total': 0,
+            }
+        aggregated[status]['records_count'] += int(row.get('records_count') or 0)
+        aggregated[status]['net_total'] += float(row.get('net_total') or 0)
+        aggregated[status]['total_taxes_and_charges'] += float(row.get('total_taxes_and_charges') or 0)
+        aggregated[status]['grand_total'] += float(row.get('grand_total') or 0)
+    return aggregated
+
+
+def build_summary_rows(aggregated_map):
+    rows = []
+    for status in CANONICAL_STATUSES:
+        rows.append(
+            aggregated_map.get(status)
+            or {
+                'integration_status': status,
+                'records_count': 0,
+                'net_total': 0,
+                'total_taxes_and_charges': 0,
+                'grand_total': 0,
+            }
+        )
+    return rows
+
+
+def get_pie_chart_data(title, labels, values, height=250, colors=None):
+    options = {
+        'title': title,
+        'data': {'labels': labels, 'datasets': [{'values': [values[label] for label in labels]}]},
+        'type': 'pie',
+        'height': height,
+        'colors': colors,
+    }
+    return options


### PR DESCRIPTION
**Target:** lavaloon-eg/ksa_compliance `develop`
**Head:** abdopcnet:fix/zatca-integration-reports
**Compare:** https://github.com/lavaloon-eg/ksa_compliance/compare/develop...abdopcnet:ksa_compliance:fix/zatca-integration-reports

---

## Summary

- Extend **Zatca Integration Details** and **Zatca Integration Summary** to Sales Invoice, POS Invoice, and prepayment Payment Entry
- Safer filter defaults and SIAF join on `sales_invoice + invoice_doctype + is_latest`
- Summary shows all canonical statuses (including zeros); Details adds reconciliation columns
- Summary opens Details with current filters via **Integration Details** button

## Problem

**Old:**

- Reports tracked Sales Invoice only; SIAF join ignored `invoice_doctype`
- Empty filters could crash; Summary hid missing statuses and imported pie chart from Details

**New:**

- Per-doctype row logic for SI, POS, and prepayment PE
- JS filter defaults; optional branch and date-validation filters on Details
- Summary uses a local chart helper; consolidated POS Sales Invoices excluded from SI filter

## Files changed

- `ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.py`
- `ksa_compliance/ksa_compliance/report/zatca_integration_details/zatca_integration_details.js`
- `ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.py`
- `ksa_compliance/ksa_compliance/report/zatca_integration_summary/zatca_integration_summary.js`
