### PR TITLE
fix: correct swapped Arabic reasons for VATEX-SA-29 and VATEX-SA-29-7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Fix swapped Arabic exemption-reason texts for VATEX-SA-29 (Financial services) and VATEX-SA-29-7
+  (Life insurance services), verified against the ZATCA Electronic Invoice XML Implementation Standard
+  v1.2 (2023-05-19)
+
 ## 0.61.7
 
 Contributed by [Saleh](https://github.com/HotSalsa10)

--- a/ksa_compliance/standard_doctypes/tax_category.py
+++ b/ksa_compliance/standard_doctypes/tax_category.py
@@ -49,11 +49,11 @@ def _reason_to_code_and_arabic(reason: str, input_reason: Optional[str] = None) 
     reasons = {
         'Financial services mentioned in Article 29 of the VAT Regulations': {
             'reason_code': 'VATEX-SA-29',
-            'arabic_reason': 'عقد تأمين على الحياة',
+            'arabic_reason': 'الخدمات المالية',
         },
         'Life insurance services mentioned in Article 29 of the VAT Regulations': {
             'reason_code': 'VATEX-SA-29-7',
-            'arabic_reason': 'الخدمات المالية',
+            'arabic_reason': 'عقد تأمين على الحياة',
         },
         'Real estate transactions mentioned in Article 30 of the VAT Regulations': {
             'reason_code': 'VATEX-SA-30',


### PR DESCRIPTION
The Arabic \`TaxExemptionReason\` texts for "Financial services" (VATEX-SA-29) and "Life insurance services" (VATEX-SA-29-7) were swapped in \`_reason_to_code_and_arabic\`. Reason codes were correct; only the human-readable Arabic emitted into the invoice XML was crossed.

Verified against the ZATCA Electronic Invoice XML Implementation Standard v1.2 (2023-05-19), p.32/72, "Tax exemption (or exception) reason code and text - specific to Saudi Arabia" table (UN/CEFACT code list 5305, D.16B subset):
- \`VATEX-SA-29\` → الخدمات المالية (Financial services)
- \`VATEX-SA-29-7\` → عقد تأمين على الحياة (Life insurance contract)

Added a unit test pinning the corrected mapping. Full existing test suite passes on ERPNext v16.