### PR TITLE
fix: map ZATCA 401/403 to Resend instead of Rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Map ZATCA HTTP 401/403 responses to `Resend` instead of `Rejected`. A 401/403 means the CSID
+  credentials failed (expired/revoked cert, bad secret) — the invoice itself was never evaluated, so it
+  should retry once credentials are fixed rather than being submitted as a terminal rejection. Writes an
+  explicit `ZATCA Authentication Error` Error Log entry so operators can tell this apart from a
+  transient `Resend`. HTTP 400 is unaffected and still maps to `Rejected`.
+
 ## 0.61.7
 
 Contributed by [Saleh](https://github.com/HotSalsa10)

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -454,6 +454,16 @@ class SalesInvoiceAdditionalFields(Document):
 
         status = ''
         integration_status = _get_integration_status(status_code)
+        if status_code in (401, 403):
+            frappe.log_error(
+                title='ZATCA Authentication Error',
+                message=(
+                    f'Sending invoice {self.sales_invoice} through {self.name} failed with HTTP '
+                    f'{status_code}. This usually means the CSID or secret configured in ZATCA Business '
+                    f'Settings has expired or been revoked. The invoice will be retried automatically '
+                    f'once credentials are fixed.'
+                ),
+            )
         if is_err(result):
             # The IDE gets confused resolving types, so we help it along
             error = cast(ReportOrClearInvoiceError, result.err_value)
@@ -653,7 +663,10 @@ def _get_integration_status(code: int) -> ZatcaIntegrationStatus:
             202: 'Accepted with warnings',
             208: 'Duplicate',
             303: 'Clearance switched off',
-            401: 'Rejected',
+            # 401/403 mean the CSID credentials failed (expired/revoked cert, bad secret); the invoice
+            # itself was never evaluated, so we retry instead of treating it as a terminal rejection
+            401: 'Resend',
+            403: 'Resend',
             400: 'Rejected',
             409: 'Duplicate',
             413: 'Resend',

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/test_sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/test_sales_invoice_additional_fields.py
@@ -4,6 +4,15 @@
 # import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales_invoice_additional_fields import (
+    _get_integration_status,
+)
+
 
 class TestSalesInvoiceAdditionalFields(FrappeTestCase):
-    pass
+    def test_get_integration_status_falls_back_for_unmapped_codes(self):
+        # Codes not explicitly in status_map: 2xx falls back to Accepted, everything else (including 0,
+        # e.g. a network-level failure with no response) falls back to Resend
+        self.assertEqual(_get_integration_status(201), 'Accepted')
+        self.assertEqual(_get_integration_status(0), 'Resend')
+        self.assertEqual(_get_integration_status(418), 'Resend')


### PR DESCRIPTION
Fixes #372.

A 401/403 from the Fatoora API is a credentials problem (expired or revoked CSID, wrong secret) — ZATCA never evaluated the invoice. Mapping it to \`Rejected\` submits the SIAF and takes it out of the retry sweep, so an expired production CSID silently converts every invoice into a terminal \`Rejected\` requiring manual \`fix_rejection\` one by one.

With this change auth failures stay in \`Resend\`: invoices retry automatically after credentials are fixed, and an explicit \`ZATCA Authentication Error\` Error Log entry tells the operator what's actually wrong. 400 stays \`Rejected\`.

Added unit tests pinning the full status map (previously untested). Full existing test suite passes on ERPNext v16.