### PR TITLE
feat: configurable customer name source for ZATCA XML (closes #313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Add an optional "Customer Name Field for XML" setting to `ZATCA Business Settings`. When set to a
+  Customer fieldname (e.g. an Arabic legal name custom field) and populated on the buyer, that value is
+  used as the buyer's `RegistrationName` in the ZATCA XML instead of Customer Name. Falls back to
+  Customer Name if left unset or empty for a given customer. Works for Sales Invoice, POS Invoice, and
+  prepayment Payment Entries. Closes #313.
+
 ## 0.61.6
 
 * Detect and correct negative zero discount (-0.0) for invoices generated with a precision higher than two digits

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/test_zatca_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/test_zatca_business_settings.py
@@ -1,9 +1,27 @@
 # Copyright (c) 2024, Lavaloon and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from ksa_compliance.ksa_compliance.doctype.zatca_business_settings.zatca_business_settings import (
+    ZATCABusinessSettings,
+)
 
 
 class TestZATCABusinessSettings(FrappeTestCase):
-    pass
+    def test_validate_allows_unset_customer_name_field(self):
+        settings = ZATCABusinessSettings.__new__(ZATCABusinessSettings)
+        settings.customer_name_field = None
+        settings.validate()
+
+    def test_validate_allows_existing_customer_field(self):
+        settings = ZATCABusinessSettings.__new__(ZATCABusinessSettings)
+        settings.customer_name_field = 'customer_name'
+        settings.validate()
+
+    def test_validate_rejects_nonexistent_customer_field(self):
+        settings = ZATCABusinessSettings.__new__(ZATCABusinessSettings)
+        settings.customer_name_field = 'this_field_does_not_exist_on_customer'
+        with self.assertRaises(frappe.ValidationError):
+            settings.validate()

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.json
@@ -57,6 +57,7 @@
   "configuration_section",
   "validate_generated_xml",
   "block_invoice_on_invalid_xml",
+  "customer_name_field",
   "column_break_cjdg",
   "fatoora_server",
   "onboarding_section",
@@ -479,6 +480,12 @@
    "fieldname": "block_invoice_on_invalid_xml",
    "fieldtype": "Check",
    "label": "Block Invoice on Invalid XML"
+  },
+  {
+   "description": "Optional fieldname on Customer to use as the buyer's registration name in the ZATCA XML instead of Customer Name (e.g. an Arabic legal name custom field). Falls back to Customer Name if left empty, or if the customer's value in this field is empty.",
+   "fieldname": "customer_name_field",
+   "fieldtype": "Data",
+   "label": "Customer Name Field for XML"
   },
   {
    "default": "0",

--- a/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_business_settings/zatca_business_settings.py
@@ -61,6 +61,7 @@ class ZATCABusinessSettings(Document):
         country_code: DF.Data | None
         csr: DF.SmallText | None
         currency: DF.Link
+        customer_name_field: DF.Data | None
         district: DF.Data | None
         enable_branch_configuration: DF.Check
         enable_zatca_integration: DF.Check
@@ -118,6 +119,16 @@ class ZATCABusinessSettings(Document):
             'NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ=='
         )
         invoice_counting_doc.insert(ignore_permissions=True)
+
+    def validate(self):
+        if self.customer_name_field and not frappe.get_meta('Customer').has_field(self.customer_name_field):
+            fthrow(
+                ft(
+                    'Field $field does not exist on Customer. Please check the field name in '
+                    '"Customer Name Field for XML".',
+                    field=self.customer_name_field,
+                )
+            )
 
     def before_insert(self):
         if self.automatic_vat_account_configuration == 1:

--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -625,14 +625,37 @@ class Einvoice:
             parent='buyer_details',
         )
 
+        self._set_buyer_registration_name()
+
+        # --------------------------- END Buyer Details fields ------------------------------
+
+    def _set_buyer_registration_name(self):
+        """
+        Sets the buyer's XML registration name. If ZATCA Business Settings has a configured customer
+        name field (e.g. an Arabic legal name custom field), and the buyer's Customer has a non-empty
+        value for it, that value is used. Otherwise, falls back to the invoice's customer name, as
+        before. The lookup goes through the Customer doc (not the invoice's own name field) so
+        Payment Entry-based prepayment invoices get the same treatment as Sales/POS Invoices.
+        """
+        custom_field = self.business_settings_doc.customer_name_field
+        if custom_field:
+            customer_id = (
+                self.sales_invoice_doc.party
+                if self.sales_invoice_doc.doctype == 'Payment Entry'
+                else self.sales_invoice_doc.customer
+            )
+            custom_name = frappe.db.get_value('Customer', customer_id, custom_field)
+            custom_name = strip(custom_name) if isinstance(custom_name, str) else custom_name
+            if custom_name:
+                self.set_value('buyer_details', 'registration_name', custom_name)
+                return
+
         self.get_text_value(
             field_name='customer_name',
             source_doc=self.sales_invoice_doc,
             xml_name='registration_name',
             parent='buyer_details',
         )
-
-        # --------------------------- END Buyer Details fields ------------------------------
 
     def append_to_item_lines(self, item_lines: list, is_tax_included: bool, sales_invoice_doc: SalesInvoice) -> None:
         """

--- a/ksa_compliance/output_models/test_e_invoice_output_model.py
+++ b/ksa_compliance/output_models/test_e_invoice_output_model.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, LavaLoon and contributors
+# For license information, please see license.txt
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ksa_compliance.output_models.e_invoice_output_model import Einvoice
+
+
+def _make_einvoice(sales_invoice_doc: dict, customer_name_field: str | None) -> Einvoice:
+    """
+    Builds a bare Einvoice instance without running __init__, so this stays a pure unit test of
+    _set_buyer_registration_name without needing Company/Customer/Sales Invoice DB fixtures.
+    """
+    einvoice = Einvoice.__new__(Einvoice)
+    einvoice.sales_invoice_doc = frappe._dict(sales_invoice_doc)
+    einvoice.business_settings_doc = frappe._dict(customer_name_field=customer_name_field)
+    einvoice.result = {'buyer_details': {}}
+    return einvoice
+
+
+class TestEinvoiceBuyerRegistrationName(FrappeTestCase):
+    def test_falls_back_to_customer_name_when_setting_is_unset(self):
+        einvoice = _make_einvoice(
+            {'doctype': 'Sales Invoice', 'customer': 'CUST-001', 'customer_name': 'Acme Corp'},
+            customer_name_field=None,
+        )
+        einvoice._set_buyer_registration_name()
+        self.assertEqual(einvoice.result['buyer_details']['registration_name'], 'Acme Corp')
+
+    def test_uses_custom_field_when_set_and_populated(self):
+        einvoice = _make_einvoice(
+            {'doctype': 'Sales Invoice', 'customer': 'CUST-001', 'customer_name': 'Acme Corp'},
+            customer_name_field='custom_customer_name_arabic',
+        )
+        with patch('frappe.db.get_value', return_value='شركة أكمي'):
+            einvoice._set_buyer_registration_name()
+        self.assertEqual(einvoice.result['buyer_details']['registration_name'], 'شركة أكمي')
+
+    def test_falls_back_to_customer_name_when_custom_field_is_empty(self):
+        einvoice = _make_einvoice(
+            {'doctype': 'Sales Invoice', 'customer': 'CUST-001', 'customer_name': 'Acme Corp'},
+            customer_name_field='custom_customer_name_arabic',
+        )
+        with patch('frappe.db.get_value', return_value=None):
+            einvoice._set_buyer_registration_name()
+        self.assertEqual(einvoice.result['buyer_details']['registration_name'], 'Acme Corp')
+
+    def test_looks_up_customer_via_party_for_payment_entry(self):
+        einvoice = _make_einvoice(
+            {'doctype': 'Payment Entry', 'party': 'CUST-002', 'party_name': 'Beta LLC'},
+            customer_name_field='custom_customer_name_arabic',
+        )
+        with patch('frappe.db.get_value', return_value='شركة بيتا') as mock_get_value:
+            einvoice._set_buyer_registration_name()
+        mock_get_value.assert_called_once_with('Customer', 'CUST-002', 'custom_customer_name_arabic')
+        self.assertEqual(einvoice.result['buyer_details']['registration_name'], 'شركة بيتا')


### PR DESCRIPTION
Implements the design discussed in #313: a new optional "Customer Name Field for XML" setting on ZATCA Business Settings naming a Customer fieldname (e.g. \`custom_customer_name_arabic\`). When set and populated for a customer, that value is emitted as the buyer \`RegistrationName\`; otherwise behavior is unchanged (\`customer_name\`). Works for Sales Invoice, POS Invoice, and prepayment Payment Entries (lookup via the Customer doc, not the invoice's own name field). Fieldname is validated against Customer's doctype meta on settings save.

Added unit tests covering the unset case, populated/empty custom field, the Payment Entry lookup path, and the settings validation. Full existing test suite passes on ERPNext v16.