### PR TITLE
Notify when invoices are stuck in the ZATCA sync queue (closes #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Notify System Managers (Error Log + desk notification) when Sales Invoice Additional Fields have
+  been waiting to sync with ZATCA for longer than 6 hours. Runs hourly, independently of the sync
+  job itself, so it still fires when the sync queue is stuck. Closes #332
+* Fix `add_batch_to_background_queue`'s `check_date` default being evaluated once at import time
+  instead of on each call
+
 ## 0.61.6
 
 * Detect and correct negative zero discount (-0.0) for invoices generated with a precision higher than two digits

--- a/ksa_compliance/background_jobs.py
+++ b/ksa_compliance/background_jobs.py
@@ -14,7 +14,9 @@ from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales
 
 
 @frappe.whitelist()
-def add_batch_to_background_queue(check_date=datetime.date.today()):
+def add_batch_to_background_queue(check_date=None):
+    if check_date is None:
+        check_date = datetime.date.today()
     try:
         logger.info('Start Enqueue E-Invoices')
         frappe.enqueue(

--- a/ksa_compliance/background_jobs.py
+++ b/ksa_compliance/background_jobs.py
@@ -2,7 +2,10 @@ import datetime
 from typing import Optional, cast
 
 import frappe
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.query_builder import DocType
+from frappe.utils import get_url_to_list, now_datetime
+from frappe.utils.user import get_users_with_role
 from pypika import Order
 from pypika.queries import QueryBuilder
 from result import is_ok
@@ -11,6 +14,12 @@ from ksa_compliance import logger
 from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales_invoice_additional_fields import (
     SalesInvoiceAdditionalFields,
 )
+
+# Statuses that are eligible to be picked up by the hourly sync batch
+BATCH_ELIGIBLE_STATUSES = ['Ready For Batch', 'Resend', 'Corrected']
+
+# How long a batch-eligible Sales Invoice Additional Fields can sit unsynced before we alert
+STUCK_INVOICE_THRESHOLD_HOURS = 6
 
 
 @frappe.whitelist()
@@ -85,14 +94,68 @@ def sync_e_invoices(
 
 
 def build_query(check_date: Optional[datetime.datetime], limit: int) -> QueryBuilder:
-    batch_status = ['Ready For Batch', 'Resend', 'Corrected']
     doctype = DocType('Sales Invoice Additional Fields')
     query = (
         frappe.qb.from_(doctype)
         .select(doctype.name, doctype.creation)
-        .where((doctype.integration_status.isin(batch_status)) & (doctype.docstatus == 0))
+        .where((doctype.integration_status.isin(BATCH_ELIGIBLE_STATUSES)) & (doctype.docstatus == 0))
     )
     if check_date:
         query = query.where(doctype.creation > check_date)
     query = query.orderby(doctype.creation, order=Order.asc).limit(limit)
     return query
+
+
+def find_stuck_invoices(threshold_hours: int = STUCK_INVOICE_THRESHOLD_HOURS) -> list[dict]:
+    """
+    Finds draft Sales Invoice Additional Fields in a batch-eligible status whose creation date is
+    older than threshold_hours, ordered oldest first.
+    """
+    cutoff = now_datetime() - datetime.timedelta(hours=threshold_hours)
+    doctype = DocType('Sales Invoice Additional Fields')
+    query = (
+        frappe.qb.from_(doctype)
+        .select(doctype.name, doctype.creation, doctype.integration_status)
+        .where(
+            (doctype.integration_status.isin(BATCH_ELIGIBLE_STATUSES))
+            & (doctype.docstatus == 0)
+            & (doctype.creation < cutoff)
+        )
+        .orderby(doctype.creation, order=Order.asc)
+    )
+    return query.run(as_dict=True)
+
+
+def notify_stuck_invoices(threshold_hours: int = STUCK_INVOICE_THRESHOLD_HOURS) -> None:
+    """
+    Alerts System Managers when Sales Invoice Additional Fields have been waiting to sync with ZATCA
+    for longer than threshold_hours. Writes one Error Log entry and one desk notification per run;
+    it doesn't track what it already reported, so a stall still stuck on the next run raises again.
+    """
+    stuck = find_stuck_invoices(threshold_hours)
+    if not stuck:
+        return
+
+    oldest = stuck[0]
+    oldest_age_hours = (now_datetime() - oldest.creation).total_seconds() / 3600
+    list_url = get_url_to_list('Sales Invoice Additional Fields')
+    message = (
+        f'{len(stuck)} Sales Invoice Additional Fields have been waiting to sync with ZATCA for more '
+        f'than {threshold_hours} hour(s). The oldest ({oldest.name}) has been waiting '
+        f'{oldest_age_hours:.1f} hours. This usually means the sync scheduler has stopped, or invoices '
+        f'are stuck cycling in Resend. List: {list_url}'
+    )
+    frappe.log_error(title='ZATCA Sync Stuck', message=message)
+
+    recipients = get_users_with_role('System Manager')
+    if recipients:
+        enqueue_create_notification(
+            recipients,
+            {
+                'type': 'Alert',
+                'subject': f'{len(stuck)} invoice(s) stuck syncing with ZATCA',
+                'document_type': 'Sales Invoice Additional Fields',
+                'document_name': oldest.name,
+                'email_content': message,
+            },
+        )

--- a/ksa_compliance/hooks.py
+++ b/ksa_compliance/hooks.py
@@ -164,7 +164,10 @@ doc_events = {
 # Scheduled Tasks
 # ---------------
 
-scheduler_events = {'hourly_long': ['ksa_compliance.background_jobs.sync_e_invoices']}
+scheduler_events = {
+    'hourly': ['ksa_compliance.background_jobs.notify_stuck_invoices'],
+    'hourly_long': ['ksa_compliance.background_jobs.sync_e_invoices'],
+}
 # "all": [
 # "ksa_compliance.tasks.all"
 # ],

--- a/ksa_compliance/test_background_jobs.py
+++ b/ksa_compliance/test_background_jobs.py
@@ -1,0 +1,79 @@
+import datetime
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import now_datetime
+
+from ksa_compliance.background_jobs import (
+    STUCK_INVOICE_THRESHOLD_HOURS,
+    add_batch_to_background_queue,
+    find_stuck_invoices,
+)
+
+
+class TestAddBatchToBackgroundQueue(FrappeTestCase):
+    @patch('ksa_compliance.background_jobs.frappe.enqueue')
+    def test_uses_current_date_at_call_time(self, mock_enqueue):
+        # The old implementation used check_date=datetime.date.today() as a default value, which is
+        # evaluated once at import time. This subclass simulates the passage of time between two calls
+        # to prove the date is now resolved fresh on each call, not frozen at definition time.
+        class FixedDate(datetime.date):
+            fixed = datetime.date(2024, 1, 1)
+
+            @classmethod
+            def today(cls):
+                return cls.fixed
+
+        with patch('ksa_compliance.background_jobs.datetime.date', FixedDate):
+            add_batch_to_background_queue()
+        first_call_date = mock_enqueue.call_args.kwargs['check_date']
+
+        FixedDate.fixed = datetime.date(2024, 6, 1)
+        with patch('ksa_compliance.background_jobs.datetime.date', FixedDate):
+            add_batch_to_background_queue()
+        second_call_date = mock_enqueue.call_args.kwargs['check_date']
+
+        self.assertEqual(first_call_date, datetime.date(2024, 1, 1))
+        self.assertEqual(second_call_date, datetime.date(2024, 6, 1))
+
+
+class TestFindStuckInvoices(FrappeTestCase):
+    def setUp(self):
+        self.created_names = []
+
+    def tearDown(self):
+        for name in self.created_names:
+            frappe.db.delete('Sales Invoice Additional Fields', {'name': name})
+
+    def _make_siaf(self, name: str, integration_status: str, docstatus: int, age_hours: float):
+        # Raw SQL bypasses Sales Invoice Additional Fields' insert/validate hooks (invoice counter,
+        # PIH chain, ZATCA Business Settings lookups), which need a real, fully-formed Sales Invoice
+        # and aren't relevant to testing find_stuck_invoices' status/docstatus/threshold filtering.
+        creation = now_datetime() - datetime.timedelta(hours=age_hours)
+        frappe.db.sql(
+            """
+            insert into `tabSales Invoice Additional Fields`
+                (name, creation, modified, owner, modified_by, docstatus, integration_status, sales_invoice)
+            values (%(name)s, %(creation)s, %(creation)s, 'Administrator', 'Administrator', %(docstatus)s,
+                    %(status)s, %(name)s)
+            """,
+            {'name': name, 'creation': creation, 'docstatus': docstatus, 'status': integration_status},
+        )
+        self.created_names.append(name)
+
+    def test_respects_status_docstatus_and_threshold(self):
+        old_hours = STUCK_INVOICE_THRESHOLD_HOURS + 1
+        fresh_hours = STUCK_INVOICE_THRESHOLD_HOURS - 1
+
+        self._make_siaf('test-stuck-old-draft', 'Resend', 0, old_hours)
+        self._make_siaf('test-stuck-fresh-draft', 'Ready For Batch', 0, fresh_hours)
+        self._make_siaf('test-stuck-old-submitted', 'Ready For Batch', 1, old_hours)
+        self._make_siaf('test-stuck-old-ineligible-status', 'Rejected', 0, old_hours)
+
+        stuck_names = {row.name for row in find_stuck_invoices()}
+
+        self.assertIn('test-stuck-old-draft', stuck_names)
+        self.assertNotIn('test-stuck-fresh-draft', stuck_names)
+        self.assertNotIn('test-stuck-old-submitted', stuck_names)
+        self.assertNotIn('test-stuck-old-ineligible-status', stuck_names)


### PR DESCRIPTION
**Title:** Notify when invoices are stuck in the ZATCA sync queue (closes #332)

**Body:**

Invoices can silently sit in `Ready For Batch`/`Resend` (scheduler stopped, network issues, auth
failures) — #332 reports one stuck for two weeks, unnoticed. Since simplified invoices must reach
ZATCA within 24 hours, operators need a signal, not a report they have to remember to open.

Discussed the approach on #332 first before building.

## What's here

- Adds an hourly check for draft Sales Invoice Additional Fields older than a threshold (default
  6h) in a batch-eligible status (`Ready For Batch`/`Resend`/`Corrected`). When found, it writes
  one Error Log entry (count + oldest age + a link to the list) and one desk notification (bell)
  to users with the System Manager role.
- Runs on the `hourly` queue, independently of `hourly_long` (which the sync job uses), so it
  still fires when the sync queue itself is wedged — that's exactly the failure it's meant to
  detect.
- No email by default (site email config can't be assumed); Error Log + bell is a conservative
  baseline that's easy to extend.
- One log/notification per run — it doesn't track what it already reported, so a stall still
  present on the next run raises again. Noting this here per the maintainer discussion in case a
  different repeat-suppression behavior is preferred.

Also fixes `add_batch_to_background_queue`'s `check_date` default (`datetime.date.today()`) being
evaluated once at import time instead of on each call — separate commit, same file/subsystem.

## Non-goals

- No email/SMS channels.
- No auto-remediation beyond the existing sweep.
- No dashboard/report changes (that's #360's territory).

## Test plan

- [x] New unit test for the detection query (`find_stuck_invoices`): draft/aged, draft/fresh,
      submitted/aged, and status-ineligible/aged fixtures — only the draft+aged, eligible-status
      one is flagged.
- [ ] New unit test for `add_batch_to_background_queue`: confirms `check_date` reflects the
      current date at call time, not the date the module was imported.
- [x] Full existing `ksa_compliance` test suite green.
- [ ] Sandbox: four invoice types clear as baseline. Deferred — this PR touches no
      submission/signing/XML/clearance logic (it only reads `Sales Invoice Additional Fields` and
      writes Error Log/Notification Log entries), and ZATCA sandbox onboarding hasn't started yet
      on our end. Happy to run this once sandbox access exists.
