### PR TITLE
Add timeout + safe temp files to the ZATCA CLI signing subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Add a timeout to the ZATCA CLI signing subprocess, and clean up the temp files it uses (invoice XML,
+  signed XML, CSR config, PDF/A-3b conversion inputs/outputs). Previously a hung CLI process could
+  block indefinitely while holding the invoice counter lock, stalling invoice creation for the whole
+  company; temp files were also never deleted and used a deprecated, insecure creation API
+  (`tempfile.mktemp`)
+
 ## 0.61.6
 
 * Detect and correct negative zero discount (-0.0) for invoices generated with a precision higher than two digits

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -216,55 +216,58 @@ class SalesInvoiceAdditionalFields(Document):
             settings.zatca_cli_path, settings.java_home, invoice_xml, cert_path, settings.private_key_path
         )
 
-        if settings.validate_generated_xml and not self.is_compliance_mode:
-            validation_result = cli.validate_invoice(
-                settings.zatca_cli_path,
-                settings.java_home,
-                result.signed_invoice_path,
-                settings.cert_path,
-                self.previous_invoice_hash,
-            )
-            self.validation_messages = '\n'.join(validation_result.messages)
-            self.validation_errors = '\n'.join(validation_result.errors_and_warnings)
-            if validation_result.details:
-                logger.info(f'Validation Errors: {validation_result.details.errors}')
-                logger.info(f'Validation Warnings: {validation_result.details.warnings}')
-
-                # In theory, we shouldn't have an invalid result without errors/warnings, but just in case an unknown
-                # error occurs that isn't captured
-                is_invalid = (
-                    (not validation_result.details.is_valid)
-                    or validation_result.details.errors
-                    or validation_result.details.warnings
+        try:
+            if settings.validate_generated_xml and not self.is_compliance_mode:
+                validation_result = cli.validate_invoice(
+                    settings.zatca_cli_path,
+                    settings.java_home,
+                    result.signed_invoice_path,
+                    settings.cert_path,
+                    self.previous_invoice_hash,
                 )
-                if settings.block_invoice_on_invalid_xml and is_invalid:
-                    html_message = ''
-                    text_message = ''
-                    if validation_result.details.errors:
-                        text_message += ft('Errors') + '\n'
-                        html_message += f'<h4>{ft("Errors")}</h4>'
-                        html_message += '<ul>'
-                        for code, error in validation_result.details.errors.items():
-                            html_message += f'<li><b>{html.escape(code)}</b>: {html.escape(error)}</li>'
-                            text_message += f'{code}: {error}\n'
-                        html_message += '</ul>'
+                self.validation_messages = '\n'.join(validation_result.messages)
+                self.validation_errors = '\n'.join(validation_result.errors_and_warnings)
+                if validation_result.details:
+                    logger.info(f'Validation Errors: {validation_result.details.errors}')
+                    logger.info(f'Validation Warnings: {validation_result.details.warnings}')
 
-                    if validation_result.details.warnings:
-                        text_message += ft('Warnings') + '\n'
-                        html_message += f'<h4>{ft("Warnings")}</h4>'
-                        html_message += '<ul>'
-                        for code, warning in validation_result.details.warnings.items():
-                            html_message += f'<li><b>{html.escape(code)}</b>: {html.escape(warning)}</li>'
-                            text_message += f'{code}: {warning}\n'
-                        html_message += '</ul>'
-
-                    frappe.log_error(
-                        title=ft('ZATCA Validation Error'),
-                        message=text_message + '\n\n' + invoice_xml,
-                        reference_doctype=self.invoice_doctype,
-                        reference_name=self.sales_invoice,
+                    # In theory, we shouldn't have an invalid result without errors/warnings, but just in case an
+                    # unknown error occurs that isn't captured
+                    is_invalid = (
+                        (not validation_result.details.is_valid)
+                        or validation_result.details.errors
+                        or validation_result.details.warnings
                     )
-                    fthrow(title=ft('ZATCA Validation Error'), msg=html_message)
+                    if settings.block_invoice_on_invalid_xml and is_invalid:
+                        html_message = ''
+                        text_message = ''
+                        if validation_result.details.errors:
+                            text_message += ft('Errors') + '\n'
+                            html_message += f'<h4>{ft("Errors")}</h4>'
+                            html_message += '<ul>'
+                            for code, error in validation_result.details.errors.items():
+                                html_message += f'<li><b>{html.escape(code)}</b>: {html.escape(error)}</li>'
+                                text_message += f'{code}: {error}\n'
+                            html_message += '</ul>'
+
+                        if validation_result.details.warnings:
+                            text_message += ft('Warnings') + '\n'
+                            html_message += f'<h4>{ft("Warnings")}</h4>'
+                            html_message += '<ul>'
+                            for code, warning in validation_result.details.warnings.items():
+                                html_message += f'<li><b>{html.escape(code)}</b>: {html.escape(warning)}</li>'
+                                text_message += f'{code}: {warning}\n'
+                            html_message += '</ul>'
+
+                        frappe.log_error(
+                            title=ft('ZATCA Validation Error'),
+                            message=text_message + '\n\n' + invoice_xml,
+                            reference_doctype=self.invoice_doctype,
+                            reference_name=self.sales_invoice,
+                        )
+                        fthrow(title=ft('ZATCA Validation Error'), msg=html_message)
+        finally:
+            cli.remove_temp_file(result.signed_invoice_path)
 
         self.invoice_hash = result.invoice_hash
         self.qr_code = result.qr_code
@@ -719,8 +722,11 @@ def download_zatca_pdf(id: str, print_format: str = 'ZATCA Phase 2 Print Format'
         settings.zatca_cli_path, settings.java_home, siaf.sales_invoice, pdf_file, xml_content
     )
 
-    with open(zatca_pdf_path, 'rb') as f:
-        pdf_content = f.read()
+    try:
+        with open(zatca_pdf_path, 'rb') as f:
+            pdf_content = f.read()
+    finally:
+        cli.remove_temp_file(zatca_pdf_path)
 
     frappe.response.filename = f'{siaf.sales_invoice}_a3b.pdf'
     frappe.response.filecontent = pdf_content

--- a/ksa_compliance/test_zatca_cli.py
+++ b/ksa_compliance/test_zatca_cli.py
@@ -1,0 +1,104 @@
+import os
+import subprocess
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from ksa_compliance.zatca_cli import (
+    ZATCA_CLI_TIMEOUT_SECONDS,
+    ZatcaResult,
+    convert_to_pdf_a3_b,
+    get_temp_path,
+    reserve_temp_path,
+    run_command,
+    sign_invoice,
+    write_binary_temp_file,
+    write_temp_file,
+)
+
+
+class TestRunCommandTimeout(FrappeTestCase):
+    @patch('ksa_compliance.zatca_cli.os.path.isfile', return_value=True)
+    @patch('ksa_compliance.zatca_cli.subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='zatca-cli', timeout=1))
+    def test_timeout_produces_failure_result_not_an_exception(self, mock_run, mock_isfile):
+        result = run_command('/fake/zatca-cli', ['-v'], java_home=None)
+
+        self.assertIsInstance(result, ZatcaResult)
+        self.assertTrue(result.is_failure)
+        self.assertIsNone(result.data)
+
+    @patch('ksa_compliance.zatca_cli.os.path.isfile', return_value=True)
+    @patch('ksa_compliance.zatca_cli.subprocess.run')
+    def test_subprocess_run_receives_configured_timeout(self, mock_run, mock_isfile):
+        mock_run.return_value.stdout = b'{"msg": "ok", "data": {}}'
+        mock_run.return_value.returncode = 0
+
+        run_command('/fake/zatca-cli', ['-v'], java_home=None)
+
+        self.assertEqual(mock_run.call_args.kwargs['timeout'], ZATCA_CLI_TIMEOUT_SECONDS)
+
+
+class TestTempPathCreation(FrappeTestCase):
+    def test_get_temp_path_creates_the_file_atomically(self):
+        path = get_temp_path('foo.xml')
+        try:
+            self.assertTrue(os.path.exists(path))
+        finally:
+            os.remove(path)
+
+    def test_reserve_temp_path_does_not_leave_a_file_behind(self):
+        path = reserve_temp_path('signed_invoice.xml')
+        self.assertFalse(os.path.exists(path))
+        self.assertTrue(path.endswith('-signed_invoice.xml'))
+
+
+class TestSignInvoiceCleanup(FrappeTestCase):
+    @patch('ksa_compliance.zatca_cli.run_command')
+    def test_removes_invoice_temp_file_even_when_signing_fails(self, mock_run_command):
+        mock_run_command.return_value = ZatcaResult(is_success=False, msg='Signing failed', errors=[], data=None)
+
+        captured_paths = []
+        real_write_temp_file = write_temp_file
+
+        def spy_write_temp_file(content, name):
+            path = real_write_temp_file(content, name)
+            captured_paths.append(path)
+            return path
+
+        with patch('ksa_compliance.zatca_cli.write_temp_file', side_effect=spy_write_temp_file):
+            with self.assertRaises(Exception):
+                sign_invoice('/fake/zatca-cli', None, '<xml/>', '/fake/cert.pem', '/fake/key.privkey')
+
+        self.assertEqual(len(captured_paths), 1)
+        self.assertFalse(os.path.exists(captured_paths[0]))
+
+
+class TestConvertToPdfA3bCleanup(FrappeTestCase):
+    @patch('ksa_compliance.zatca_cli.run_command')
+    def test_removes_input_temp_files_after_a_successful_conversion(self, mock_run_command):
+        mock_run_command.return_value = ZatcaResult(
+            is_success=True, msg='Converted', errors=[], data={'filePath': '/fake/output.pdf'}
+        )
+
+        captured_paths = []
+        real_write_binary_temp_file = write_binary_temp_file
+        real_write_temp_file = write_temp_file
+
+        def spy_write_binary_temp_file(content, name):
+            path = real_write_binary_temp_file(content, name)
+            captured_paths.append(path)
+            return path
+
+        def spy_write_temp_file(content, name):
+            path = real_write_temp_file(content, name)
+            captured_paths.append(path)
+            return path
+
+        with patch('ksa_compliance.zatca_cli.write_binary_temp_file', side_effect=spy_write_binary_temp_file):
+            with patch('ksa_compliance.zatca_cli.write_temp_file', side_effect=spy_write_temp_file):
+                result_path = convert_to_pdf_a3_b('/fake/zatca-cli', None, 'SINV-001', b'%PDF-1.4', '<xml/>')
+
+        self.assertEqual(result_path, '/fake/output.pdf')
+        self.assertEqual(len(captured_paths), 2)
+        for path in captured_paths:
+            self.assertFalse(os.path.exists(path))

--- a/ksa_compliance/zatca_cli.py
+++ b/ksa_compliance/zatca_cli.py
@@ -23,6 +23,7 @@ from ksa_compliance.zatca_files import get_csr_path, get_private_key_path, get_z
 DEFAULT_CLI_VERSION = '2.10.0'
 DEFAULT_JRE_URL = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.23_9.tar.gz'
 DEFAULT_CLI_URL = f'https://github.com/lavaloon-eg/zatca-cli/releases/download/{DEFAULT_CLI_VERSION}/zatca-cli-{DEFAULT_CLI_VERSION}.zip'
+ZATCA_CLI_TIMEOUT_SECONDS = 60
 
 
 @dataclass
@@ -208,17 +209,20 @@ def generate_csr(
     Generates a CSR. The given prefix is used to name the resulting CSR and private key files.
     """
     config_path = write_temp_file(config, f'{file_prefix}-csr.properties')
-    csr_path = get_csr_path(file_prefix)
-    private_key_path = get_private_key_path(file_prefix)
-    args = ['csr', '-c', config_path, '-o', csr_path, '-k', private_key_path]
-    if simulation:
-        args.append('-s')
-    result = run_command(zatca_cli_path, args, java_home=java_home)
-    logger.info(result.msg)
-    result.throw_if_failure()
-    with open(csr_path, 'rt') as file:
-        csr = file.read()
-    return CsrResult(csr, csr_path, private_key_path)
+    try:
+        csr_path = get_csr_path(file_prefix)
+        private_key_path = get_private_key_path(file_prefix)
+        args = ['csr', '-c', config_path, '-o', csr_path, '-k', private_key_path]
+        if simulation:
+            args.append('-s')
+        result = run_command(zatca_cli_path, args, java_home=java_home)
+        logger.info(result.msg)
+        result.throw_if_failure()
+        with open(csr_path, 'rt') as file:
+            csr = file.read()
+        return CsrResult(csr, csr_path, private_key_path)
+    finally:
+        remove_temp_file(config_path)
 
 
 def sign_invoice(
@@ -226,17 +230,37 @@ def sign_invoice(
 ) -> SigningResult:
     base_path = os.path.normpath(os.path.join(os.path.dirname(zatca_cli_path), '../'))
     invoice_path = write_temp_file(invoice_xml, 'invoice.xml')
-    signed_invoice_path = get_temp_path('signed_invoice.xml')
-    result = run_command(
-        zatca_cli_path,
-        ['sign', '-b', base_path, '-o', signed_invoice_path, '-c', cert_path, '-k', private_key_path, invoice_path],
-        java_home=java_home,
-    )
-    logger.info(result.msg)
-    result.throw_if_failure()
-    with open(signed_invoice_path, 'rt') as file:
-        signed_invoice = file.read()
-    return SigningResult(signed_invoice, signed_invoice_path, result.data['hash'], result.data['qrCode'])
+    # The CLI itself creates signed_invoice_path (via -o), not us, so we only reserve a securely-random
+    # name for it rather than pre-creating the file - see reserve_temp_path's docstring. It's returned
+    # to the caller (still needed for validate_invoice), so cleanup is the caller's responsibility.
+    signed_invoice_path = reserve_temp_path('signed_invoice.xml')
+    try:
+        result = run_command(
+            zatca_cli_path,
+            [
+                'sign',
+                '-b',
+                base_path,
+                '-o',
+                signed_invoice_path,
+                '-c',
+                cert_path,
+                '-k',
+                private_key_path,
+                invoice_path,
+            ],
+            java_home=java_home,
+        )
+        logger.info(result.msg)
+        result.throw_if_failure()
+        with open(signed_invoice_path, 'rt') as file:
+            signed_invoice = file.read()
+        return SigningResult(signed_invoice, signed_invoice_path, result.data['hash'], result.data['qrCode'])
+    except Exception:
+        remove_temp_file(signed_invoice_path)
+        raise
+    finally:
+        remove_temp_file(invoice_path)
 
 
 def validate_invoice(
@@ -274,7 +298,13 @@ def run_command(zatca_cli_path: str, args: List[str], java_home: Optional[str]) 
     if java_home:
         env['JAVA_HOME'] = java_home
     logger.info(f'Running: {full_args}')
-    proc = subprocess.run(full_args, capture_output=True, env=env)
+    try:
+        proc = subprocess.run(full_args, capture_output=True, env=env, timeout=ZATCA_CLI_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        message = f'ZATCA CLI did not respond within {ZATCA_CLI_TIMEOUT_SECONDS} seconds'
+        logger.error(message)
+        return ZatcaResult(is_success=False, msg=message, errors=[message], data=None)
+
     try:
         result = cast(dict, json.loads(proc.stdout))
     except JSONDecodeError:
@@ -304,7 +334,36 @@ def write_binary_temp_file(content: bytes, name: str) -> str:
 
 
 def get_temp_path(name: str) -> str:
-    return tempfile.mktemp(suffix='-' + name)
+    """Reserves a unique path for a temp file that we write ourselves (write_temp_file /
+    write_binary_temp_file open and overwrite it immediately after). Uses tempfile.mkstemp, which
+    creates the file atomically with owner-only (0600) permissions, instead of tempfile.mktemp, which
+    only returns a name - a documented race condition (TOCTOU) between generating the name and
+    creating the file, and no permission guarantee once created via a plain open()."""
+    fd, path = tempfile.mkstemp(suffix='-' + name)
+    os.close(fd)
+    return path
+
+
+def reserve_temp_path(name: str) -> str:
+    """Reserves a securely-random, unique-at-reservation-time path for a file that a subprocess (not
+    us) will create - e.g. the ZATCA CLI's signed-invoice output. We can't pre-create the file the way
+    get_temp_path does here: invoice signing is handled by a closed-source SDK inside the CLI, so we
+    can't confirm it overwrites a pre-existing file rather than erroring on one. Using mkstemp then
+    immediately removing it still gets a cryptographically-unpredictable name (unlike the mktemp() this
+    replaces), even though a narrow creation race remains inherent to handing a path to another
+    process to create."""
+    fd, path = tempfile.mkstemp(suffix='-' + name)
+    os.close(fd)
+    os.remove(path)
+    return path
+
+
+def remove_temp_file(path: str) -> None:
+    """Best-effort removal of a temp file we're done with; a missing file is not an error"""
+    try:
+        os.remove(path)
+    except OSError:
+        pass
 
 
 def convert_to_pdf_a3_b(
@@ -313,11 +372,15 @@ def convert_to_pdf_a3_b(
     pdf = write_binary_temp_file(pdf_content, f'{invoice_id}.pdf')
     invoice_xml = write_temp_file(xml_content, f'{invoice_id}.xml')
 
-    result = run_command(
-        zatca_cli_path,
-        ['convert-pdf', '-i', invoice_id, '-x', invoice_xml, pdf],
-        java_home=java_home,
-    )
-    logger.info(result.msg)
-    result.throw_if_failure()
-    return result.data['filePath']
+    try:
+        result = run_command(
+            zatca_cli_path,
+            ['convert-pdf', '-i', invoice_id, '-x', invoice_xml, pdf],
+            java_home=java_home,
+        )
+        logger.info(result.msg)
+        result.throw_if_failure()
+        return result.data['filePath']
+    finally:
+        remove_temp_file(pdf)
+        remove_temp_file(invoice_xml)


### PR DESCRIPTION
**Title:** Add timeout + safe temp files to the ZATCA CLI signing subprocess

**Body:**

`run_command` shells out to the ZATCA CLI with no `subprocess` timeout, while `_prepare_for_zatca`
holds a row lock on `ZATCA Invoice Counting Settings` (needed to serialize the invoice counter/PIH
chain) for the entire duration of the call. If the CLI process hangs, that lock is held indefinitely,
and every other invoice submission for the same company blocks behind it — not just the one hung
invoice.

Separately, temp files for invoice XML/signed XML/CSR config/PDF conversion go through
`tempfile.mktemp`, which Python's docs deprecate over a TOCTOU race, and were never cleaned up — every
invoice ever signed left 2+ files with real invoice content sitting in the system temp directory
indefinitely.

## What's here

- `run_command` now passes a timeout (60s constant — open question below) to `subprocess.run` and
  catches `TimeoutExpired`, converting it into a normal `ZatcaResult(is_success=False, ...)` rather than
  an unhandled exception, matching the function's existing error-handling pattern.
- `get_temp_path` (used for files we write ourselves — invoice XML, CSR config, PDF conversion inputs)
  now uses `tempfile.mkstemp`, which creates the file atomically with 0600 permissions, instead of
  `tempfile.mktemp`, which only returns a name.
- One exception: the signed-invoice output path (`-o` target for `sign`) is created by the CLI itself,
  and I traced `SignCommand.kt` to confirm the actual write goes through a closed-source SDK
  (`com.gazt.einvoicing.signing.service.InvoiceSigningService`) I can't verify overwrite behavior for.
  So that path uses a new `reserve_temp_path` helper instead — same secure `mkstemp`-based naming, but
  removed immediately after reservation, leaving the CLI to create it fresh exactly as before. (For
  what it's worth: `CsrCommand`/`Main.kt`/`cert.kt` all use plain `FileOutputStream`, which does
  overwrite existing files — so `-o` targets for `csr` and `convert-pdf` would likely be fine to
  pre-create too, but I didn't want to guess on the one that's closed-source.)
- Temp files are now removed after use: CSR config in `generate_csr`, the raw invoice XML in
  `sign_invoice`, the signed invoice XML in `_prepare_for_zatca` (after validation, since
  `validate_invoice` needs it first), and both PDF-conversion inputs plus the CLI's converted-PDF output
  in `convert_to_pdf_a3_b`/`download_zatca_pdf`. Traced every use of each returned path first to confirm
  nothing downstream still needs the file at cleanup time.

No changes to CLI arguments, result parsing, counter/PIH updates, or validation semantics — timeout,
temp-file creation, and cleanup only.

## Open question

Is 60s a reasonable timeout constant, or would you rather this be configurable (e.g. on ZATCA Business
Settings)? Signing involves a JVM call plus crypto, so I picked something more generous than the HTTP
timeout in #370, but I don't have a strong signal on real-world signing latency across different
hosting setups.

## Test plan

- [x] Unit tests: timeout produces a failure result, not an exception; `subprocess.run` receives the
      timeout kwarg; `get_temp_path` creates a real file immediately; `reserve_temp_path` leaves no file
      behind; `sign_invoice` removes its input temp file even when signing fails; `convert_to_pdf_a3_b`
      removes both its input temp files after a successful conversion.
- [x] Full existing `ksa_compliance` test suite green.
- [ ] Sandbox: sign a real invoice end-to-end, confirm signing still succeeds and no temp files are
      left behind. Deferred — no ZATCA sandbox onboarding exists on our end yet (same gap noted on
      #370/#371/#373/#374/#375). This PR doesn't change what gets signed or how results are parsed, so
      the risk surface for this gap is narrow, but flagging per the usual practice.
