### PR TITLE
Fix truncated seconds in prepayment document-reference IssueTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Fix `_format_time` hardcoding the seconds component to `00` in a prepayment invoice's document
+  reference `IssueTime`. The referenced prepayment invoice's own submission reports its real issue
+  time (including seconds), so the two records of the same timestamp could disagree
+
 ## 0.61.6
 
 * Detect and correct negative zero discount (-0.0) for invoices generated with a precision higher than two digits

--- a/ksa_compliance/output_models/prepayment_invoice/invoice_line_factory.py
+++ b/ksa_compliance/output_models/prepayment_invoice/invoice_line_factory.py
@@ -73,10 +73,11 @@ def _get_uuid(document_reference: PaymentEntry) -> str:
 
 def _format_time(time_delta: timedelta) -> str:
     """Convert timedelta to HH:MM:SS format"""
-    total_seconds = time_delta.total_seconds()
-    hours = int(total_seconds // 3600)
-    minutes = int((total_seconds % 3600) // 60)
-    return f'{hours:02d}:{minutes:02d}:00'
+    total_seconds = int(time_delta.total_seconds())
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+    return f'{hours:02d}:{minutes:02d}:{seconds:02d}'
 
 
 def _get_tax_info(document_reference: PaymentEntry) -> tuple[float, str]:

--- a/ksa_compliance/output_models/prepayment_invoice/test_invoice_line_factory.py
+++ b/ksa_compliance/output_models/prepayment_invoice/test_invoice_line_factory.py
@@ -1,0 +1,22 @@
+from datetime import timedelta
+
+from frappe.tests.utils import FrappeTestCase
+
+from ksa_compliance.output_models.prepayment_invoice.invoice_line_factory import _format_time
+
+
+class TestFormatTime(FrappeTestCase):
+    def test_includes_real_seconds_instead_of_hardcoded_zero(self):
+        self.assertEqual(_format_time(timedelta(hours=14, minutes=23, seconds=47)), '14:23:47')
+
+    def test_zero_seconds(self):
+        self.assertEqual(_format_time(timedelta(hours=9, minutes=5, seconds=0)), '09:05:00')
+
+    def test_zero_pads_single_digit_components(self):
+        self.assertEqual(_format_time(timedelta(hours=1, minutes=2, seconds=3)), '01:02:03')
+
+    def test_truncates_fractional_seconds(self):
+        self.assertEqual(_format_time(timedelta(hours=10, minutes=30, seconds=15, milliseconds=900)), '10:30:15')
+
+    def test_midnight(self):
+        self.assertEqual(_format_time(timedelta(hours=0, minutes=0, seconds=0)), '00:00:00')


### PR DESCRIPTION
**Title:** Fix truncated seconds in prepayment document-reference IssueTime

**Body:**

A Sales/POS invoice referencing a ZATCA prepayment invoice reports the wrong `IssueTime` for that
reference. `_format_time` computed hours and minutes correctly from the underlying `timedelta` but
hardcoded seconds to `00`, so e.g. `14:23:47` becomes `14:23:00` in the `AdditionalDocumentReference`.
The prepayment invoice's own submission (`get_time_value` in `e_invoice_output_model.py`) reports the
real, correct seconds for the same timestamp — so the two records of the same event could disagree.

This computes seconds from the timedelta like the rest of the value, instead of discarding them.

## Test plan

- [x] New unit tests for `_format_time`: real-seconds case, zero-seconds case, single-digit
      zero-padding, fractional-second truncation, midnight — pure function, no DB fixtures needed.
- [x] Full existing suite green.
- [ ] Sandbox: submit a prepayment Payment Entry + a consuming invoice, confirm
      `AdditionalDocumentReference/cbc:IssueTime` matches the prepayment invoice's own `IssueTime` down
      to the second. Deferred — no ZATCA sandbox onboarding on our end yet (same gap as
      #370/#371/#373/#374/#375/#377).

## Non-goals

- No changes to how the prepayment invoice's own `IssueTime` is computed (already correct, untouched).
- No changes to `DocumentReference.issue_date` or any other field.
