### PR TITLE
Fix app_license metadata

### DIFF
--- a/ksa_compliance/hooks.py
+++ b/ksa_compliance/hooks.py
@@ -3,7 +3,7 @@ app_title = 'KSA Compliance'
 app_publisher = 'LavaLoon'
 app_description = 'KSA Compliance app for E-invoice'
 app_email = 'info@lavaloon.com'
-app_license = 'Copyright (c) 2023 LavaLoon'
+app_license = 'GNU Affero General Public License (v3)'
 # required_apps = []
 
 # Includes in <head>


### PR DESCRIPTION
**Title:** Fix `app_license` metadata

**Body:**

`app_license` in `hooks.py` was set to `'Copyright (c) 2023 LavaLoon'` — a copyright string, not a
license identifier. Frappe's `app_license` field is meant to hold a license name (sibling apps in the
same bench set it to `"MIT"` for frappe/payments, `"GNU General Public License (v3)"` for erpnext); it's
surfaced in Frappe's app list / About-This-App UI and read by `bench` tooling. The repo's actual
`LICENSE` file is AGPL v3, so the previous string was wrong in both kind and content.

One-line fix, matching the naming style of the sibling apps already in this bench.

## Test plan

- [x] Full existing suite green (metadata-only change; no functional test applies).
- [ ] Manual: confirm `bench`/Frappe's "About This App" dialog shows the corrected string. Not run in
      this PR (no UI access in this environment) — low risk given the change is a single string
      literal with no code paths depending on its value.

## Non-goals

- No `LICENSE` file changes (already correct).
- No other `hooks.py` metadata fields touched.
