### PR TITLE
Don't mark invoices accepted when the ZATCA response can't be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Retry invoices instead of marking them accepted when a ZATCA response can't be parsed.
+
 ## 0.61.7
 
 Contributed by [Saleh](https://github.com/HotSalsa10)

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/sales_invoice_additional_fields.py
@@ -458,6 +458,10 @@ class SalesInvoiceAdditionalFields(Document):
             # The IDE gets confused resolving types, so we help it along
             error = cast(ReportOrClearInvoiceError, result.err_value)
             zatca_message = error.response or error.error
+            if integration_status in ('Accepted', 'Accepted with warnings'):
+                # We got a 2xx but couldn't parse the body, so we don't actually know what ZATCA said.
+                # Resend is safe: if it was accepted, retrying comes back as a duplicate.
+                integration_status = 'Resend'
         else:
             value = cast(ReportOrClearInvoiceResult, result.ok_value)
             zatca_message = value.raw_response

--- a/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/test_sales_invoice_additional_fields.py
+++ b/ksa_compliance/ksa_compliance/doctype/sales_invoice_additional_fields/test_sales_invoice_additional_fields.py
@@ -1,9 +1,40 @@
 # Copyright (c) 2024, Lavaloon and Contributors
 # See license.txt
 
-# import frappe
+from typing import cast
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from result import Err
+
+from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales_invoice_additional_fields import (
+    SalesInvoiceAdditionalFields,
+)
+from ksa_compliance.zatca_api import ReportOrClearInvoiceError
+
+REPORT_INVOICE = (
+    'ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales_invoice_additional_fields.api'
+    '.report_invoice'
+)
 
 
 class TestSalesInvoiceAdditionalFields(FrappeTestCase):
-    pass
+    def test_send_xml_via_api_resends_on_unparseable_2xx_but_not_on_a_real_error(self):
+        doc = cast(SalesInvoiceAdditionalFields, frappe.new_doc('Sales Invoice Additional Fields'))
+        doc.invoice_doctype = 'Sales Invoice'
+        doc.sales_invoice = 'SINV-TEST-0001'
+        doc.uuid = 'test-uuid'
+
+        with patch.object(SalesInvoiceAdditionalFields, '_add_integration_log_document'):
+            # ZATCA answered 200 but the body wasn't parseable, so we don't actually know it accepted
+            # the invoice. We shouldn't take its word for it and should retry instead.
+            with patch(REPORT_INVOICE, return_value=(Err(ReportOrClearInvoiceError('', 'boom')), 200)):
+                status = doc._send_xml_via_api('<xml/>', 'hash', 'Simplified', 'https://example.com', 'token', 'secret')
+            self.assertEqual(status, 'Resend')
+            self.assertEqual(doc.integration_status, 'Resend')
+
+            # A real rejection should still be a rejection, not silently downgraded to Resend.
+            with patch(REPORT_INVOICE, return_value=(Err(ReportOrClearInvoiceError('', 'invalid')), 400)):
+                status = doc._send_xml_via_api('<xml/>', 'hash', 'Simplified', 'https://example.com', 'token', 'secret')
+            self.assertEqual(status, 'Rejected')


### PR DESCRIPTION
If ZATCA (or a proxy in front of it) answers with a 2xx but a body we fail to parse, `api_call` returns an error result while keeping the 2xx status code. `_send_xml_via_api` derives the integration status from that status code alone, so the invoice gets marked Accepted and the additional fields doc gets submitted even though we never actually read ZATCA's answer. If the invoice didn't really make it, nothing retries it and there's no sign of trouble outside the integration log.

This falls back to Resend in that case. It's safe: if ZATCA did accept the invoice the first time, the retry just comes back as a duplicate, which is already a terminal status. Easiest way to hit this is a 200 with a non-JSON body, e.g. from a proxy/gateway in front of ZATCA.
