### PR TITLE
Escape the remaining free-text fields in the invoice XML template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Escape the buyer VAT registration number, discount reason (header and line level), and prepayment
+  line description in the invoice XML template.
+
 ## 0.61.7
 
 Contributed by [Saleh](https://github.com/HotSalsa10)

--- a/ksa_compliance/templates/e_invoice.xml
+++ b/ksa_compliance/templates/e_invoice.xml
@@ -119,7 +119,7 @@
             </cac:PostalAddress>
             {% if buyer_details.company_id %}
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>{{ buyer_details.company_id }}</cbc:CompanyID>
+                <cbc:CompanyID>{{ buyer_details.company_id | escape }}</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -152,7 +152,7 @@
         <cbc:AllowanceChargeReasonCode>{{ allowance_charge.allowance_charge_reason_code }}</cbc:AllowanceChargeReasonCode>
         {% endif %}
         {% if allowance_charge.allowance_charge_reason %}
-        <cbc:AllowanceChargeReason>{{ allowance_charge.allowance_charge_reason }}</cbc:AllowanceChargeReason>
+        <cbc:AllowanceChargeReason>{{ allowance_charge.allowance_charge_reason | escape }}</cbc:AllowanceChargeReason>
         {% endif %}
         <cbc:Amount currencyID="{{ invoice.currency_code }}">{{ rounded(allowance_charge.amount, 2) }}</cbc:Amount>
             <cac:TaxCategory>
@@ -247,7 +247,7 @@
                 <cbc:AllowanceChargeReasonCode>{{ item.allowance_charge_reason_code }}</cbc:AllowanceChargeReasonCode>
                 {% endif %}
                 {% if item.allowance_charge_reason %}
-                <cbc:AllowanceChargeReason>{{ item.allowance_charge_reason }}</cbc:AllowanceChargeReason>
+                <cbc:AllowanceChargeReason>{{ item.allowance_charge_reason | escape }}</cbc:AllowanceChargeReason>
                 {% endif %}
                 <cbc:Amount currencyID="{{ invoice.currency_code }}">{{ rounded(item.discount_amount, 2) }}</cbc:Amount>
                 <cbc:BaseAmount currencyID="{{ invoice.currency_code }}">{{ rounded(item.base_amount, 2) }}</cbc:BaseAmount>
@@ -302,7 +302,7 @@
             </cac:TaxSubtotal>
         </cac:TaxTotal>
         <cac:Item>
-            <cbc:Name>{{row.item.name}}</cbc:Name>
+            <cbc:Name>{{row.item.name | escape}}</cbc:Name>
             <cac:ClassifiedTaxCategory>
                 <cbc:ID>{{row.item.tax_category}}</cbc:ID>
                 <cbc:Percent>{{row.item.tax_percent}}</cbc:Percent>


### PR DESCRIPTION
A few free-text fields in e_invoice.xml are rendered without the escape filter the rest of the template uses: the buyer VAT registration number, the discount reason (header and line level), and the prepayment line description. An `&` or `<` in any of them — an easy typo in a VAT number, or something like "Advance & deposit" as a prepayment description — produces invalid XML, so signing fails and the invoice can't be submitted. This adds the missing escape filters; the equivalent fields elsewhere in the template already have them.
