### PR TITLE
fix: derive VAT category amounts from the invoice-level VAT (BR-CO-14/15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+* Fix invoices rejected under `BR-CO-14` (invoice total VAT amount must equal the sum of the VAT category tax amounts)
+  and `BR-CO-15` (invoice total with VAT must equal invoice total without VAT plus total VAT)
+  * ERPNext fills `Sales Invoice Item.tax_amount` through the Saudi regional override, which rounds each line's VAT
+    independently. The sum of those lines can drift a few halalas away from `total_taxes_and_charges`, the amount
+    ERPNext books to the general ledger and the one we render as `BT-110`, so the VAT breakdown disagreed with it.
+    A single halala is enough to be rejected, and the drift runs in both directions
+  * `BR-CO-15` was hit by the same drift: ZATCA resolves `BT-110` for that rule from the VAT breakdown rather than
+    from `cac:TaxTotal/cbc:TaxAmount`, so the invoice was rejected whenever the drift fell on the wrong side. Since
+    the breakdown now always sums to `BT-110`, both readings agree and the rule holds either way
+  * The VAT breakdown is now derived from the invoice-level VAT, in proportion to the VAT each category is expected
+    to carry (taxable amount × rate) so that zero rated and exempt categories keep a VAT amount of 0 (`BR-Z-09`,
+    `BR-E-09`) and every category still satisfies `BR-CO-17`
+  * A difference too large to be rounding (an invoice discount applied on grand total, or a non-VAT charge in the
+    taxes table) is deliberately *not* redistributed, so ZATCA reports the underlying inconsistency instead of the
+    app hiding it behind a `BR-CO-17` violation
+  * Prepayment invoices are unaffected: a `Payment Entry` adjusts its VAT after the breakdown is built
+* Add tests for the VAT breakdown, covering `BR-CO-14`, `BR-CO-17` and `BR-Z-09`/`BR-E-09`
+
 ## 0.61.4
 
 * Fix migration failure due to a reference to a non-existent patch in patches.txt

--- a/ksa_compliance/output_models/e_invoice_output_model.py
+++ b/ksa_compliance/output_models/e_invoice_output_model.py
@@ -900,7 +900,13 @@ class Einvoice:
         )
         self.append_to_item_lines(item_lines, is_tax_included, self.sales_invoice_doc)
         tax_categories = create_tax_categories(self.sales_invoice_doc, item_lines, is_tax_included)
-        tax_total = create_tax_total(tax_categories)
+        # Anchor the VAT breakdown on the invoice-level VAT so BT-110 and Σ BT-117 agree (BR-CO-14).
+        # Payment Entry is excluded: its total is adjusted further below for non-'Actual' charge
+        # types, so the figure rendered as BT-110 is not the one available here.
+        invoice_total_vat = None
+        if self.sales_invoice_doc.doctype != 'Payment Entry':
+            invoice_total_vat = abs(flt(self.sales_invoice_doc.total_taxes_and_charges or 0.0))
+        tax_total = create_tax_total(tax_categories, invoice_total_vat)
         self.result['invoice']['tax_total'] = tax_total
         allowance_charge = create_allowance_charge(self.sales_invoice_doc, tax_total)
         self.result['invoice']['allowance_charge'] = allowance_charge

--- a/ksa_compliance/output_models/tax.py
+++ b/ksa_compliance/output_models/tax.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import flt
 
 from ksa_compliance.standard_doctypes.tax_category import map_tax_category
 from .service import get_right_fieldname, dataclass_to_frappe_dict
@@ -91,20 +92,60 @@ def check_item_tax_template(doc: SalesInvoice, item_lines: list, sales_taxes_and
         )
 
 
-def create_tax_total(tax_categories: dict) -> dict:
+# These are NOT a tolerance ZATCA grants us: BR-CO-14 is checked for exact equality, and a single
+# halala of difference is rejected. They decide something else entirely, namely whether a gap
+# between the invoice-level VAT and the line-derived VAT is small enough to be explained by
+# per-line rounding, in which case the breakdown is safe to re-derive from the invoice-level
+# amount. A wider gap means the lines and the invoice genuinely disagree, and no allocation can
+# rescue that invoice, so we leave it alone rather than corrupt the breakdown.
+#
+# The smallest gap we always treat as rounding drift, however few lines the invoice has:
+MAX_ROUNDING_DRIFT = 0.05
+
+# Plus an allowance per item line, since ERPNext rounds each line's VAT to the currency precision
+# and the error accumulates with the number of lines.
+MAX_ROUNDING_DRIFT_PER_LINE = 0.01
+
+
+def create_tax_total(tax_categories: dict, total_taxes_and_charges: float | None = None) -> dict:
+    """Build the invoice's VAT breakdown (``cac:TaxTotal``).
+
+    Line-level VAT comes from ``Sales Invoice Item.tax_amount``, which the Saudi regional override
+    recomputes per line as ``flt(net_amount * rate / 100, precision)``. Rounding each line
+    independently means Σ(line VAT) can drift a few halalas away from ``total_taxes_and_charges``,
+    the figure ERPNext books to the general ledger and the one rendered as BT-110. One halala is
+    enough for ZATCA to reject the invoice under BR-CO-14 (BT-110 = Σ BT-117), and the drift runs
+    in both directions depending on where the per-line rounding falls.
+
+    It also decides BR-CO-15 (BT-112 = BT-109 + BT-110). ZATCA resolves BT-110 there from the VAT
+    breakdown rather than from ``cac:TaxTotal/cbc:TaxAmount``, so the same drift breaks that rule
+    too whenever it happens to fall on the wrong side.
+
+    When *total_taxes_and_charges* is given, the category amounts are therefore derived from it
+    instead of from the lines, so BT-110 and Σ BT-117 cannot disagree. The share each category
+    receives is proportional to the VAT that category is *expected* to carry
+    (``taxable amount × rate``), never to its taxable amount alone -- otherwise a zero rated or
+    exempt category would be handed VAT and fail BR-Z-09/BR-E-09, and the standard rated category
+    would fail BR-CO-17.
+
+    A gap too wide to be rounding is left alone; see [MAX_ROUNDING_DRIFT].
+    """
+    amounts_by_category = {key: _get_amounts(tax_categories[key]) for key in tax_categories}
+    tax_amount_by_category = _allocate_tax_amounts(tax_categories, amounts_by_category, total_taxes_and_charges)
+
     tax_sub_totals = []
     tax_amount = 0
     taxable_amount = 0
     total_discount = 0
     for key in tax_categories:
-        amounts = _get_amounts(tax_categories[key])
+        amounts = amounts_by_category[key]
         tax_sub_total = TaxSubtotal(
             taxable_amount=amounts.taxable_amount,
-            tax_amount=amounts.tax_amount,
+            tax_amount=tax_amount_by_category[key],
             tax_category=tax_categories[key].tax_category,
             total_discount=amounts.total_discount,
         )
-        tax_amount += amounts.tax_amount
+        tax_amount += tax_sub_total.tax_amount
         taxable_amount += amounts.taxable_amount
         total_discount += amounts.total_discount
         tax_sub_totals.append(tax_sub_total)
@@ -112,6 +153,50 @@ def create_tax_total(tax_categories: dict) -> dict:
     return dataclass_to_frappe_dict(
         TaxTotal(tax_amount=tax_amount, taxable_amount=taxable_amount, tax_subtotal=tax_sub_totals)
     )
+
+
+def _allocate_tax_amounts(
+    tax_categories: dict, amounts_by_category: dict, total_taxes_and_charges: float | None
+) -> dict:
+    """Decide the VAT amount (BT-117) of each tax category. See [create_tax_total] for the rules."""
+    line_amounts = {key: amounts_by_category[key].tax_amount for key in tax_categories}
+    if total_taxes_and_charges is None:
+        return line_amounts
+
+    # flt rounds through frappe.utils.data.rounded, which honours the system's rounding method.
+    # The XML template rounds every amount the same way, so anchoring on flt keeps the breakdown
+    # consistent with the BT-110 that ends up in the XML.
+    target = flt(total_taxes_and_charges, 2)
+    if flt(target - sum(line_amounts.values()), 2) == 0.0:
+        return line_amounts
+
+    expected = {
+        key: flt(
+            amounts_by_category[key].taxable_amount * flt(tax_categories[key].tax_category.percent or 0.0) / 100, 2
+        )
+        for key in tax_categories
+    }
+    expected_total = sum(expected.values())
+    if not expected_total:
+        return line_amounts
+
+    line_count = sum(len(tax_categories[key].items) for key in tax_categories)
+    max_drift = max(MAX_ROUNDING_DRIFT, MAX_ROUNDING_DRIFT_PER_LINE * line_count)
+    if abs(target - expected_total) > max_drift:
+        return line_amounts
+
+    # The residue from rounding each share goes to the category carrying the most VAT, so it can
+    # never land on a zero rated, exempt or out-of-scope category.
+    residue_key = max(tax_categories, key=lambda key: expected[key])
+    allocated = 0.0
+    result = {}
+    for key in tax_categories:
+        if key == residue_key:
+            continue
+        result[key] = flt(target * expected[key] / expected_total, 2)
+        allocated += result[key]
+    result[residue_key] = flt(target - allocated, 2)
+    return result
 
 
 def _get_amounts(tax_category: TaxCategoryByItems) -> frappe._dict:

--- a/ksa_compliance/output_models/test_tax.py
+++ b/ksa_compliance/output_models/test_tax.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2026, LavaLoon and Contributors
+# See license.txt
+"""Tests for the VAT breakdown (``cac:TaxTotal``) built by :mod:`ksa_compliance.output_models.tax`.
+
+These tests are written against the ZATCA/EN 16931 business rules rather than against the
+implementation, so they stay meaningful if the allocation strategy changes:
+
+* **BR-CO-14** -- Invoice total VAT amount (BT-110) = Σ VAT category tax amount (BT-117)
+* **BR-CO-15** -- Invoice total amount with VAT (BT-112) = Invoice total amount without VAT
+  (BT-109) + Invoice total VAT amount (BT-110)
+* **BR-CO-17** -- VAT category tax amount (BT-117) = VAT category taxable amount (BT-116)
+  × (VAT category rate (BT-119) / 100), rounded to two decimals
+* **BR-Z-09 / BR-E-09 / BR-O-09** -- a zero rated, exempt or out-of-scope category carries no VAT
+
+Line-level ``tax_amount`` values are supplied explicitly instead of being derived, because that
+is what the code under test consumes: ERPNext fills ``Sales Invoice Item.tax_amount`` through the
+Saudi regional override (``erpnext.regional.united_arab_emirates.utils.update_itemised_tax_data``),
+which recomputes each line as ``flt(net_amount * rate / 100, precision)``. Rounding each line
+independently is exactly what makes Σ(line VAT) drift away from the invoice-level
+``total_taxes_and_charges``, which is the drift these tests describe.
+
+``REJECTED_INVOICES`` below is transcribed from invoices ZATCA rejected in production. Everything
+else is constructed, and worth reading as such: no production data was available for an invoice
+mixing standard rated lines with zero rated or exempt ones, so those cases assert what the rules
+require rather than something observed.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.utils import flt
+
+from ksa_compliance.output_models.models import TaxCategory, TaxCategoryByItems, ZatcaTaxCategory
+from ksa_compliance.output_models.tax import create_tax_total
+
+# ZATCA tax category codes
+STANDARD = 'S'
+ZERO_RATED = 'Z'
+EXEMPT = 'E'
+
+# Invoices ZATCA rejected in production, transcribed from the XML that was submitted.
+# Each entry is (invoice id, rate, [(line net, line VAT)], VAT booked by ERPNext).
+#
+# 05526 and 05509 price tax-inclusive, so each line's net is itself a rounded ``amount / 1.15``
+# before its VAT is rounded again. 05454 prices tax-exclusive and drifts the *other* way, which
+# is why it also tripped BR-CO-15 while the first two did not.
+REJECTED_INVOICES = (
+    ('ACC-SINV-2025-05526', 15.0, [(313.91, 47.09), (413.04, 61.96)], 109.04),
+    ('ACC-SINV-2025-05509', 15.0, [(695.65, 104.35), (834.78, 125.22)], 229.56),
+    (
+        'ACC-SINV-2025-05454',
+        15.0,
+        [
+            (1140.00, 171.00),
+            (1477.08, 221.56),
+            (919.50, 137.92),
+            (190.00, 28.50),
+            (125.00, 18.75),
+            (120.00, 18.00),
+            (40.00, 6.00),
+            (35.00, 5.25),
+            (105.00, 15.75),
+            (132.00, 19.80),
+            (279.00, 41.85),
+            (406.00, 60.90),
+            (163.00, 24.45),
+            (126.00, 18.90),
+            (235.00, 35.25),
+            (75.00, 11.25),
+            (104.00, 15.60),
+        ],
+        850.74,
+    ),
+)
+
+
+def build_item(net_amount: float, tax_amount: float, amount: float = None) -> frappe._dict:
+    """Build the minimal item line shape consumed by ``_get_amounts``."""
+    return frappe._dict(
+        net_amount=net_amount,
+        tax_amount=tax_amount,
+        amount=net_amount if amount is None else amount,
+    )
+
+
+def rounding_methods() -> list:
+    """Every rounding method System Settings offers, falling back to the configured one."""
+    field = frappe.get_meta('System Settings').get_field('rounding_method')
+    options = [option.strip() for option in (field.options or '').split('\n') if option.strip()] if field else []
+    return options or [frappe.get_system_settings('rounding_method')]
+
+
+def build_categories(*specs) -> frappe._dict:
+    """Build a tax category map from ``(key, code, percent, items)`` tuples.
+
+    Insertion order is preserved, which matters: it is the order the invoice's item lines
+    produced the categories in, and no rule may depend on it.
+    """
+    categories = frappe._dict()
+    for key, code, percent, items in specs:
+        categories[key] = TaxCategoryByItems(
+            tax_category=TaxCategory(
+                zatca_tax_category_id=ZatcaTaxCategory(tax_category_code=code),
+                percent=percent,
+                tax_scheme_id='VAT',
+            ),
+            items=list(items),
+        )
+    return categories
+
+
+class TestCreateTaxTotal(FrappeTestCase):
+    # --------------------------------------------------------------- assertions
+
+    def assert_br_co_14(self, tax_total: frappe._dict, expected_vat: float):
+        """BT-110 = Σ BT-117."""
+        total = flt(sum(flt(row.tax_amount, 2) for row in tax_total.tax_subtotal), 2)
+        self.assertEqual(
+            total,
+            flt(expected_vat, 2),
+            msg=f'BR-CO-14 violated: Σ VAT category tax amount {total} != invoice total VAT {flt(expected_vat, 2)}',
+        )
+
+    def assert_br_co_17(self, tax_total: frappe._dict):
+        """BT-117 = BT-116 × (BT-119 / 100)."""
+        for row in tax_total.tax_subtotal:
+            percent = flt(row.tax_category.percent or 0.0)
+            expected = flt(flt(row.taxable_amount) * percent / 100, 2)
+            self.assertAlmostEqual(
+                flt(row.tax_amount, 2),
+                expected,
+                delta=0.02,
+                msg=(
+                    f'BR-CO-17 violated for category '
+                    f'{row.tax_category.zatca_tax_category_id.tax_category_code} @ {percent}%: '
+                    f'tax amount {flt(row.tax_amount, 2)} != taxable {flt(row.taxable_amount, 2)} × {percent}%'
+                ),
+            )
+
+    def assert_no_vat_on_zero_rate_categories(self, tax_total: frappe._dict):
+        """BR-Z-09 / BR-E-09 / BR-O-09."""
+        for row in tax_total.tax_subtotal:
+            if flt(row.tax_category.percent or 0.0):
+                continue
+            self.assertEqual(
+                flt(row.tax_amount, 2),
+                0.0,
+                msg=(
+                    f'BR-Z-09/BR-E-09 violated: category '
+                    f'{row.tax_category.zatca_tax_category_id.tax_category_code} is rated at 0% but '
+                    f'carries {flt(row.tax_amount, 2)} of VAT'
+                ),
+            )
+
+    def assert_br_co_15(self, tax_total: frappe._dict, net_total: float, grand_total: float):
+        """BT-112 = BT-109 + BT-110.
+
+        ZATCA resolves BT-110 here from the VAT breakdown, not from ``cac:TaxTotal/cbc:TaxAmount``.
+        Across the four rejected invoices we have, that reading predicts whether BR-CO-15 was
+        reported in every case, while reading it from ``cac:TaxTotal`` predicts none of them.
+        """
+        bt110 = flt(sum(flt(row.tax_amount, 2) for row in tax_total.tax_subtotal), 2)
+        self.assertEqual(
+            flt(net_total + bt110, 2),
+            flt(grand_total, 2),
+            msg=(f'BR-CO-15 violated: BT-109 {flt(net_total, 2)} + BT-110 {bt110} != BT-112 {flt(grand_total, 2)}'),
+        )
+
+    def assert_all_rules(self, tax_total: frappe._dict, expected_vat: float):
+        self.assert_br_co_14(tax_total, expected_vat)
+        self.assert_br_co_17(tax_total)
+        self.assert_no_vat_on_zero_rate_categories(tax_total)
+
+    def subtotal_for(self, tax_total: frappe._dict, code: str) -> frappe._dict:
+        rows = [r for r in tax_total.tax_subtotal if r.tax_category.zatca_tax_category_id.tax_category_code == code]
+        self.assertEqual(len(rows), 1, msg=f'Expected exactly one {code} subtotal, found {len(rows)}')
+        return rows[0]
+
+    # --------------------------------------------------------------- test cases
+
+    def test_invoices_rejected_by_zatca(self):
+        """Invoices ZATCA actually rejected, replayed through the breakdown.
+
+        Each one is a plain single rate invoice whose only defect is that the lines and the
+        document round differently. Both drift directions are represented.
+        """
+        for invoice_id, rate, lines, invoice_vat in REJECTED_INVOICES:
+            with self.subTest(invoice=invoice_id):
+                line_vat = flt(sum(vat for _, vat in lines), 2)
+                self.assertNotEqual(
+                    line_vat,
+                    flt(invoice_vat, 2),
+                    msg=f'{invoice_id} is meant to be a drift case, but the lines already agree',
+                )
+
+                categories = build_categories(('S', STANDARD, rate, [build_item(net, vat) for net, vat in lines]))
+                tax_total = create_tax_total(categories, invoice_vat)
+
+                net_total = flt(sum(net for net, _ in lines), 2)
+                self.assert_all_rules(tax_total, invoice_vat)
+                # BT-112 as the XML builds it: BT-109 + the invoice level VAT.
+                self.assert_br_co_15(tax_total, net_total, flt(net_total + invoice_vat, 2))
+
+    def test_single_category_without_drift_is_unchanged(self):
+        """Baseline: when the line VAT already agrees with the invoice VAT, nothing moves."""
+        categories = build_categories(('S15', STANDARD, 15.0, [build_item(1000.00, 150.00)]))
+
+        tax_total = create_tax_total(categories, 150.00)
+
+        self.assert_all_rules(tax_total, 150.00)
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).taxable_amount, 2), 1000.00)
+
+    def test_single_category_absorbs_per_line_rounding_drift(self):
+        """Per-line rounding makes Σ(line VAT) 4.56 while ERPNext booked 4.54. BT-117 must follow BT-110.
+
+        Fails on master, where the subtotal is taken straight from Σ(line VAT).
+        """
+        categories = build_categories(
+            (
+                'S15',
+                STANDARD,
+                15.0,
+                [build_item(10.10, 1.52), build_item(10.10, 1.52), build_item(10.10, 1.52)],
+            )
+        )
+
+        tax_total = create_tax_total(categories, 4.54)
+
+        self.assert_all_rules(tax_total, 4.54)
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).tax_amount, 2), 4.54)
+
+    def test_standard_and_zero_rated_keep_vat_on_the_standard_category(self):
+        """A zero rated category must never be handed VAT, no matter how the residue is distributed.
+
+        Fails on any allocator that distributes the invoice VAT in proportion to *taxable amount*
+        rather than to *expected VAT*: that splits 150.00 into 75.00 / 75.00.
+        """
+        categories = build_categories(
+            ('S15', STANDARD, 15.0, [build_item(1000.00, 150.00)]),
+            ('Z0', ZERO_RATED, 0.0, [build_item(1000.00, 0.00)]),
+        )
+
+        tax_total = create_tax_total(categories, 150.00)
+
+        self.assert_all_rules(tax_total, 150.00)
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).tax_amount, 2), 150.00)
+        self.assertEqual(flt(self.subtotal_for(tax_total, ZERO_RATED).tax_amount, 2), 0.00)
+
+    def test_drift_residue_lands_on_the_standard_category_not_the_exempt_one(self):
+        """Σ(line VAT) is 15.01 but ERPNext booked 15.00; the exempt category must stay at 0.00.
+
+        Fails on master (BR-CO-14: 15.01 != 15.00) *and* on a taxable-weighted allocator, which
+        hands 5.00 of VAT to the exempt category because it holds a third of the taxable amount.
+        """
+        categories = build_categories(
+            ('S15', STANDARD, 15.0, [build_item(33.33, 5.00), build_item(66.67, 10.01)]),
+            ('E0', EXEMPT, 0.0, [build_item(50.00, 0.00)]),
+        )
+
+        tax_total = create_tax_total(categories, 15.00)
+
+        self.assert_all_rules(tax_total, 15.00)
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).tax_amount, 2), 15.00)
+        self.assertEqual(flt(self.subtotal_for(tax_total, EXEMPT).tax_amount, 2), 0.00)
+
+    def test_two_non_zero_rates_are_weighted_by_rate_not_by_taxable_amount(self):
+        """Equal taxable amounts at 15% and 5% must keep their 150/50 split, not become 100/100.
+
+        Fails on a taxable-weighted allocator (BR-CO-17: 100.00 != 1000.00 × 15%).
+        """
+        categories = build_categories(
+            ('S15', STANDARD, 15.0, [build_item(1000.00, 150.00)]),
+            ('S5', STANDARD, 5.0, [build_item(1000.00, 50.00)]),
+        )
+
+        tax_total = create_tax_total(categories, 199.99)
+
+        self.assert_br_co_14(tax_total, 199.99)
+        self.assert_br_co_17(tax_total)
+        by_rate = {flt(r.tax_category.percent): flt(r.tax_amount, 2) for r in tax_total.tax_subtotal}
+        self.assertAlmostEqual(by_rate[15.0], 150.00, delta=0.02)
+        self.assertAlmostEqual(by_rate[5.0], 50.00, delta=0.02)
+
+    def test_omitting_the_invoice_vat_preserves_line_derived_amounts(self):
+        """Payment Entry adjusts its VAT after the breakdown is built, so it passes no anchor.
+
+        Guards against the breakdown being pinned to a figure the template will later override.
+        """
+        categories = build_categories(
+            ('S15', STANDARD, 15.0, [build_item(10.10, 1.52), build_item(10.10, 1.52), build_item(10.10, 1.52)])
+        )
+
+        tax_total = create_tax_total(categories)
+
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).tax_amount, 2), 4.56)
+
+    def test_fully_zero_rated_invoice(self):
+        """An invoice with no VAT at all must not divide by zero."""
+        categories = build_categories(
+            ('Z0', ZERO_RATED, 0.0, [build_item(1000.00, 0.00)]),
+            ('E0', EXEMPT, 0.0, [build_item(500.00, 0.00)]),
+        )
+
+        tax_total = create_tax_total(categories, 0.00)
+
+        self.assert_all_rules(tax_total, 0.00)
+
+    def test_structural_mismatch_is_not_silently_absorbed(self):
+        """A gap far beyond rounding (here a grand total discount) must not be papered over.
+
+        ERPNext booked 100.00 of VAT while the lines, which are not discounted, imply 150.00.
+        Redistributing would hide a real data problem behind a BR-CO-17 violation, so the
+        breakdown stays line-derived and lets ZATCA report the underlying inconsistency.
+        """
+        categories = build_categories(('S15', STANDARD, 15.0, [build_item(1000.00, 150.00)]))
+
+        tax_total = create_tax_total(categories, 100.00)
+
+        self.assertEqual(flt(self.subtotal_for(tax_total, STANDARD).tax_amount, 2), 150.00)
+        self.assert_br_co_17(tax_total)
+
+    def test_drift_absorbed_under_every_rounding_method(self):
+        """The XML renders every amount through ``frappe.utils.data.rounded``, which honours the
+        system's rounding method, so the breakdown has to agree with that rather than with Python's
+        ``round``. Every configurable method is exercised.
+        """
+        methods = rounding_methods()
+        self.assertTrue(methods, msg='System Settings offers no rounding method to exercise')
+        for method in methods:
+            with self.subTest(rounding_method=method), change_settings('System Settings', rounding_method=method):
+                categories = build_categories(
+                    (
+                        'S15',
+                        STANDARD,
+                        15.0,
+                        [build_item(10.10, 1.52), build_item(10.10, 1.52), build_item(10.10, 1.52)],
+                    )
+                )
+
+                tax_total = create_tax_total(categories, 4.54)
+
+                self.assert_all_rules(tax_total, 4.54)


### PR DESCRIPTION
## Problem

Invoices are rejected by ZATCA under **BR-CO-14** — *Invoice total VAT amount (BT-110) = Σ VAT category tax amount (BT-117)* — and, on the same invoices, sometimes **BR-CO-15**.

The two sides of that equation are produced by different code paths:

- **BT-110** is rendered from `invoice.total_taxes_and_charges` — `templates/e_invoice.xml`
- **BT-117** is built in `create_tax_total` by summing `Sales Invoice Item.tax_amount` per ZATCA tax category

## Root cause

`Sales Invoice Item.tax_amount` is not written by this app or by ERPNext core. It is filled by ERPNext's regional override — `regional_overrides["Saudi Arabia"]` maps `update_itemised_tax_data` to the United Arab Emirates implementation, which recomputes each line as:

```python
tax_amount += flt((row.net_amount * _tax_rate) / 100, row.precision("tax_amount"))
```

Rounding every line independently means `Σ(line VAT)` drifts away from `total_taxes_and_charges`, which ERPNext computes across the document and books to the general ledger. A few halalas of drift is enough for ZATCA to reject the invoice.

Reproduced against current `master` — three lines of 10.10 at 15%:

```
MASTER: BT-110 = 4.54   sum(BT-117) = 4.56   -> BR-CO-14 FAIL
```

## Evidence from rejected invoices

Four invoices ZATCA rejected in production. In every one, `Σ(line VAT)` reproduces BT-117 exactly and lands one halala away from BT-110 — in **both** directions:

| id | Σ line VAT | BT-117 | BT-110 | drift |
|---|---|---|---|---|
| 05526 | 109.05 | 109.05 | 109.04 | +0.01 |
| 05509 | 229.57 | 229.57 | 229.56 | +0.01 |
| 05454 | 850.73 | 850.73 | 850.74 | **−0.01** |
| (4th) | 226.13 | 226.13 | 226.12 | +0.01 |

05526 and 05509 price tax-inclusive, so each line's net is itself a rounded `amount / 1.15` before its VAT is rounded again — two rounding stages per line. 05454 prices tax-exclusive across 17 lines and drifts the other way.

### BR-CO-15 comes from the same defect

BR-CO-15 was reported on 05454 and the 4th invoice, but not on 05526 or 05509. That is fully explained by which value ZATCA uses for BT-110:

| id | BT-109 + BT-110 | BT-109 + Σ BT-117 | BT-112 | BR-CO-15 reported |
|---|---|---|---|---|
| 05526 | 835.99 | **836.00** | 836.00 | no |
| 05509 | 1759.99 | **1760.00** | 1760.00 | no |
| 05454 | 6522.32 | **6522.31** | 6522.32 | **yes** |
| (4th) | 1733.62 | **1733.63** | 1733.62 | **yes** |

```
Which definition of BT-110 predicts the observed BR-CO-15 outcome?
  TaxTotal/TaxAmount   -> 0/4 invoices predicted correctly
  sum(TaxSubtotal)     -> 4/4 invoices predicted correctly
```

**ZATCA resolves BT-110 for BR-CO-15 from the VAT breakdown, not from `cac:TaxTotal/cbc:TaxAmount`.** This also explains why BR-CO-15 looked intermittent — it depends on which side the drift falls.

Since `BT-112` is built as `BT-109 + BT-110` and this change makes `Σ BT-117 = BT-110`, the two readings give the same number, so BR-CO-15 holds under either interpretation. All four invoices pass both rules with the fix, and BR-CO-17 holds in each with a residual of ≤0.005 — matching under half-up rounding as well, so no tolerance argument is needed.

## The fix

`create_tax_total` takes an optional `total_taxes_and_charges` and derives the category amounts from it, so BT-110 and Σ BT-117 cannot disagree.

The share each category receives is proportional to the VAT it is **expected** to carry (`taxable amount × rate`), not to its taxable amount:

- weighting by taxable amount hands VAT to zero rated and exempt categories, breaking **BR-Z-09** / **BR-E-09**, and puts the wrong amount on the standard rated one, breaking **BR-CO-17**
- the rounding residue goes to the category carrying the most VAT, so it can never land on a zero rated one

A gap too wide to be rounding is **not** redistributed. That means the lines and the invoice genuinely disagree — a discount applied on grand total, or a non-VAT charge sitting in the taxes table — and absorbing it would hide a data problem behind a BR-CO-17 violation. In that case the breakdown stays line-derived and ZATCA reports the real inconsistency.

`Payment Entry` passes no anchor, since it adjusts its own VAT for non-`Actual` charge types *after* the breakdown is built.

`flt` is used throughout rather than Python's `round`, because the XML template renders every amount through `frappe.utils.data.rounded`, which honours the system's rounding method.

## Why not simply distribute proportionally to the taxable amount

That was the first thing I tried, and it passes on single-category invoices — which is most of them, so it looks correct in production. The tests in this PR show what it does on a mixed invoice. Running the suite against that variant:

```
BR-CO-17 violated for category S @ 15.0%: tax amount 75.0  != taxable 1000.0 × 15.0%
BR-CO-17 violated for category S @ 15.0%: tax amount 10.0  != taxable  100.0 × 15.0%
BR-CO-17 violated for category S @ 15.0%: tax amount 100.0 != taxable 1000.0 × 15.0%
FAIL: test_structural_mismatch_is_not_silently_absorbed

Ran 10 tests ... FAILED (failures=4)
```

A standard-rated line of 1,000 at 15% next to a zero-rated line of 1,000 gets its 150.00 of VAT split 75.00 / 75.00 — BR-CO-14 passes, and three other rules start failing instead.

## Tests

`ksa_compliance/output_models/test_tax.py` — 10 tests asserting the ZATCA rules rather than the implementation, so they stay meaningful if the allocation strategy changes:

- **BR-CO-14** — BT-110 = Σ BT-117
- **BR-CO-15** — BT-112 = BT-109 + BT-110
- **BR-CO-17** — BT-117 = BT-116 × (BT-119 / 100)
- **BR-Z-09 / BR-E-09** — a zero rated or exempt category carries no VAT

Covered: the three rejected invoices above, no drift (baseline), single-category drift, standard + zero rated, drift residue against an exempt category, two non-zero rates, no anchor (the `Payment Entry` path), a fully zero rated invoice, a structural mismatch that must not be absorbed, and the drift case under every rounding method System Settings offers.

The commits are split so the tests can be checked out on their own — note they are red by design at that point, since they call a signature that arrives in the following commit.

## Notes for reviewers

A few related things I found while tracking this down, deliberately left out of this PR:

1. **`Accounts Settings` → "Round tax amount row-wise"** (`round_row_wise_tax`) makes ERPNext round each row's tax before accumulating, so `total_taxes_and_charges` becomes `Σ(row taxes)` by construction. Worth documenting as recommended configuration for ZATCA users.

2. **The deeper fix** is to stop sourcing line VAT from the regional override's custom fields and read ERPNext's own per-row tax breakup instead, which is already reconciled against the booked tax. This app already has a reader for it — `get_item_wise_tax_details()` in `jinja.py` — currently used only by the print formats. That would additionally make BT-116 post-discount, lining up BR-CO-17 and BR-CO-10 for grand-total discounts. It is a larger change and needs to account for how item wise tax details are stored across ERPNext versions.

3. **Tax-inclusive invoices understate BT-112 by a halala.** `TaxInclusiveAmount` is built as `BT-109 + BT-110`, but the per-line nets are rounded `amount / 1.15` values that cannot reproduce the exact inclusive total: 05526 reports 835.99 against 836.00 invoiced, 05509 reports 1759.99 against 1760.00. This is pre-existing and unchanged by this PR — ZATCA accepts it — but the e-invoice total then differs from the printed invoice and the GL.

4. **`get_itemised_tax` is keyed by `item_code`**, so the same item on two lines with different item tax templates receives the summed rate. Happy to open a separate issue.
